### PR TITLE
Fix startup pings to actually work

### DIFF
--- a/homeserver/outbound_general.go
+++ b/homeserver/outbound_general.go
@@ -4,20 +4,20 @@ import (
 	"context"
 	"log"
 	"net/http"
-	"net/url"
 
 	"github.com/matrix-org/gomatrixserverlib/fclient"
+	"github.com/matrix-org/gomatrixserverlib/spec"
 )
 
 // Ping - Sends an authenticated request to the given server name in an attempt to encourage
 // it to send us transactions/requests.
 func (h *Homeserver) Ping(ctx context.Context, serverName string) error {
-	mxUrl := url.URL{
-		Scheme: "matrix",
-		Host:   serverName,
-		Path:   "/_matrix/federation/v1/version",
+	fedReq := fclient.NewFederationRequest(http.MethodGet, h.ServerName, spec.ServerName(serverName), "/_matrix/federation/v1/version")
+	err := fedReq.Sign(h.ServerName, h.KeyId, h.signingKey)
+	if err != nil {
+		return err
 	}
-	req, err := http.NewRequest(http.MethodGet, mxUrl.String(), nil)
+	req, err := fedReq.HTTPRequest()
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
The endpoint doesn't require authentication, but authentication is what causes the remote server (if Synapse) to be 'tricked' into thinking we're back online. Without authentication, Synapse doesn't know what server is calling the endpoint and therefore can't refresh the "server is online" cache.

The previous code was not actually authenticating the request.

### Pull Request Checklist

<!-- Please read https://github.com/matrix-org/policyserv/CONTRIBUTING.md before submitting your pull request -->

* [x] Pull request is based on the `main` branch.
* [x] Pull request title describes the changes in a way a user would understand. For example, "Fix keywords filter not applying" instead of "Read keywords slice in a loop".
* [x] Code style matches surrounding code.
* [x] Tests are added for new code (and existing code) if possible.
  * If not possible, please explain why in your PR description. 
* [x] The CI checks pass.

