### PR TITLE
Fix: allow readonly database config to be truly optional

### DIFF
--- a/cmd/app/setup_data_handlers.go
+++ b/cmd/app/setup_data_handlers.go
@@ -16,12 +16,15 @@ func setupDataHandlers(instanceConfig *config.InstanceConfig) (storage.Persisten
 			MaxOpenConns: instanceConfig.DatabaseMaxOpenConns,
 			MaxIdleConns: instanceConfig.DatabaseMaxIdleConns,
 		},
-		RODatabase: &storage.PostgresStorageConnectionConfig{
+		RODatabase:     nil,
+		MigrationsPath: instanceConfig.DatabaseMigrationsDir,
+	}
+	if instanceConfig.DatabaseReadonlyUri != "" {
+		dbConfig.RODatabase = &storage.PostgresStorageConnectionConfig{
 			Uri:          instanceConfig.DatabaseReadonlyUri,
 			MaxOpenConns: instanceConfig.DatabaseReadonlyMaxOpen,
 			MaxIdleConns: instanceConfig.DatabaseReadonlyMaxIdle,
-		},
-		MigrationsPath: instanceConfig.DatabaseMigrationsDir,
+		}
 	}
 	psqlDb, err := storage.NewPostgresStorage(dbConfig)
 	if err != nil {


### PR DESCRIPTION
Fixes https://github.com/matrix-org/policyserv/issues/21

Issue was that we *always* set the RO config when the below code is expecting it to be nil when not available

https://github.com/matrix-org/policyserv/blob/108571daf93a9b530d73b6400f6ad8e682c684c7/storage/psql.go#L67

### Pull Request Checklist

<!-- Please read https://github.com/matrix-org/policyserv/CONTRIBUTING.md before submitting your pull request -->

* [x] Pull request is based on the `main` branch.
* [x] Pull request title describes the changes in a way a user would understand. For example, "Fix keywords filter not applying" instead of "Read keywords slice in a loop".
* [x] Code style matches surrounding code.
* [x] Tests are added for new code (and existing code) if possible.
  * If not possible, please explain why in your PR description. 
* [x] The CI checks pass.
