### PR TITLE
Maintenance: Remove deprecated join rooms API and use common authenticated handler for other endpoints

### DIFF
--- a/api/api.go
+++ b/api/api.go
@@ -56,9 +56,8 @@ func (a *Api) BindTo(mux *http.ServeMux) error {
 
 	if a.apiKey != "" {
 		log.Println("Enabling policyserv API")
-		mux.Handle("/api/v1/join_rooms", a.httpRequestHandler(httpJoinRoomApi))
-		mux.Handle("/api/v1/rooms", a.httpRequestHandler(httpGetRoomsApi))
-		mux.Handle("/api/v1/set_room_moderator", a.httpRequestHandler(httpSetModeratorApi))
+		mux.Handle("/api/v1/rooms", a.httpAuthenticatedRequestHandler(httpGetRoomsApi))
+		mux.Handle("/api/v1/set_room_moderator", a.httpAuthenticatedRequestHandler(httpSetModeratorApi))
 		mux.Handle("/api/v1/rooms/{id}", a.httpAuthenticatedRequestHandler(httpGetRoomApi))
 		mux.Handle("/api/v1/rooms/{roomId}/join", a.httpAuthenticatedRequestHandler(httpAddRoomApi))
 		mux.Handle("/api/v1/communities/new", a.httpAuthenticatedRequestHandler(httpCreateCommunityApi))

--- a/api/http_api_moderator.go
+++ b/api/http_api_moderator.go
@@ -26,12 +26,6 @@ func httpSetModeratorApi(api *Api, w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	if r.Header.Get("Authorization") != "Bearer "+api.apiKey {
-		defer metrics.RecordHttpResponse(r.Method, "httpSetModeratorApi", http.StatusUnauthorized)
-		homeserver.MatrixHttpError(w, http.StatusUnauthorized, "M_UNAUTHORIZED", "Not allowed")
-		return
-	}
-
 	b, err := io.ReadAll(r.Body)
 	if err != nil {
 		log.Println(err)

--- a/docs/api.md
+++ b/docs/api.md
@@ -6,38 +6,6 @@ Policyserv has a rudimentary API to do some common tasks. To enable the API, set
 
 Supply the `Authorization` header with a `Bearer` token matching `PS_API_KEY`. For example, if you have `PS_API_KEY=changeme` then your header would be `Authorization: Bearer changeme`.
 
-## Join Rooms API
-
-**Deprecated: Replaced by `POST /api/v1/rooms/{roomId}/join`** - do not use deprecated endpoints.
-
-When policyserv is joined to a room, it considers that room protected. Do not ask policyserv to join rooms you don't want to protect.
-
-Note: you can also use `PS_JOIN_ROOM_IDS` to join rooms. The API method just avoids a restart.
-
-Example:
-```bash
-# Set APIKEY to your PS_API_KEY value
-APIKEY=changeme
-curl -s -X POST -H "Authorization: Bearer ${APIKEY}" --data-binary '{"via":"example.org","room_ids": ["!room:example.org"]}' https://example.org/api/v1/join_rooms
-```
-
-Request method: `POST`
-Request body:
-```json
-{
-  "via": "example.org",
-  "room_ids": [
-    "!room:example.org"
-  ]
-}
-```
-
-If there's an error, a standard Matrix error will be returned. If successful, expect `{"joined_all": true}` and 200 OK.
-
-The logs can be monitored to ensure the room IDs were correctly picked up.
-
-Room joins may be retried internally, blocking the request until they complete.
-
 ## Set room moderator API
 
 **Deprecated: Not intended to be used long-term.**


### PR DESCRIPTION
During the API refactor there were a couple of endpoints which didn't get the new `httpAuthenticatedRequestHandler` treatment. Fixing this is just regular maintenance that probably should have been done earlier.

We also deprecated the `/api/v1/join_rooms` endpoint because it wasn't as useful as the new `/rooms/:roomId/join` endpoint. Our tooling (namely https://github.com/matrix-org/policyserv-setup-bot ) no longer uses the deprecated endpoint, so this should be safe to remove now. 

### Pull Request Checklist

<!-- Please read https://github.com/matrix-org/policyserv/CONTRIBUTING.md before submitting your pull request -->

* [x] Pull request is based on the `main` branch.
* [x] Pull request title describes the changes in a way a user would understand. For example, "Fix keywords filter not applying" instead of "Read keywords slice in a loop".
* [x] Code style matches surrounding code.
* [x] Tests are added for new code (and existing code) if possible.
  * If not possible, please explain why in your PR description. 
* [x] The CI checks pass.
