### PR TITLE
Fix crash on startup when specifying admin or security support contacts

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -56,9 +56,9 @@ type InstanceConfig struct {
 	HMAApiUrl string `envconfig:"hma_api_url" default:""`
 	HMAApiKey string `envconfig:"hma_api_key" default:""`
 
-	SupportAdminContacts    []*SupportContact `envconfig:"support_admin_contacts" default:""`
-	SupportSecurityContacts []*SupportContact `envconfig:"support_security_contacts" default:""`
-	SupportUrl              string            `envconfig:"support_url" default:""`
+	SupportAdminContacts    []SupportContact `envconfig:"support_admin_contacts" default:""`
+	SupportSecurityContacts []SupportContact `envconfig:"support_security_contacts" default:""`
+	SupportUrl              string           `envconfig:"support_url" default:""`
 }
 
 func NewInstanceConfig() (*InstanceConfig, error) {

--- a/config/support_contacts.go
+++ b/config/support_contacts.go
@@ -19,17 +19,20 @@ func (c *SupportContact) Decode(value string) error {
 	// Implements envconfig.Decoder
 
 	if !strings.Contains(value, "@") {
-		c.Value = ""
-		c.Type = ""
+		*c = SupportContact{
+			Value: "",
+			Type:  "",
+		}
 		return fmt.Errorf("invalid support contact value: %s", value)
 	}
 
-	c.Value = value
-
+	contactType := SupportContactTypeEmail
 	if value[0] == '@' {
-		c.Type = SupportContactTypeMatrixUserId
-	} else {
-		c.Type = SupportContactTypeEmail
+		contactType = SupportContactTypeMatrixUserId
+	}
+	*c = SupportContact{
+		Value: value,
+		Type:  contactType,
 	}
 
 	return nil

--- a/homeserver/api_basic_server_info.go
+++ b/homeserver/api_basic_server_info.go
@@ -97,7 +97,7 @@ func httpSupport(server *Homeserver, w http.ResponseWriter, r *http.Request) {
 		Contacts:   make([]wellknownSupportContact, 0),
 		SupportUrl: server.supportUrl,
 	}
-	appendContact := func(role string, contact *config.SupportContact) {
+	appendContact := func(role string, contact config.SupportContact) {
 		wkContact := wellknownSupportContact{
 			Role: role,
 		}

--- a/homeserver/api_basic_server_info_test.go
+++ b/homeserver/api_basic_server_info_test.go
@@ -54,12 +54,12 @@ func TestHttpSupport(t *testing.T) {
 	// Because we're interacting with very little of the interface, we can create a Homeserver instance without using
 	// the NewHomeserver() function.
 	server := &Homeserver{
-		adminContacts: []*config.SupportContact{
+		adminContacts: []config.SupportContact{
 			{Value: "@admin:example.org", Type: config.SupportContactTypeMatrixUserId},
 			{Value: "admin@example.org", Type: config.SupportContactTypeEmail},
 			{Value: "skipped@example.org", Type: "UNKNOWN"},
 		},
-		securityContacts: []*config.SupportContact{
+		securityContacts: []config.SupportContact{
 			{Value: "@security:example.org", Type: config.SupportContactTypeMatrixUserId},
 			{Value: "security@example.org", Type: config.SupportContactTypeEmail},
 			{Value: "skipped@example.org", Type: "UNKNOWN"},
@@ -87,7 +87,7 @@ func TestHttpSupport(t *testing.T) {
 
 	// Now start removing things from the support object to ensure it still generates a response
 
-	server.adminContacts = make([]*config.SupportContact, 0)
+	server.adminContacts = make([]config.SupportContact, 0)
 	for _, method := range []string{http.MethodGet, http.MethodOptions} {
 		log.Println("Testing method", method)
 		res := httptest.NewRecorder()
@@ -104,7 +104,7 @@ func TestHttpSupport(t *testing.T) {
 		})
 	}
 
-	server.securityContacts = make([]*config.SupportContact, 0)
+	server.securityContacts = make([]config.SupportContact, 0)
 	for _, method := range []string{http.MethodGet, http.MethodOptions} {
 		log.Println("Testing method", method)
 		res := httptest.NewRecorder()
@@ -129,7 +129,7 @@ func TestHttpSupport(t *testing.T) {
 	}
 
 	// Then, if we add back some contacts, we should get a useful response again
-	server.adminContacts = []*config.SupportContact{
+	server.adminContacts = []config.SupportContact{
 		{Value: "admin@example.org", Type: config.SupportContactTypeEmail},
 	}
 	for _, method := range []string{http.MethodGet, http.MethodOptions} {

--- a/homeserver/homeserver.go
+++ b/homeserver/homeserver.go
@@ -36,8 +36,8 @@ type Config struct {
 	EnableDirectKeyFetching bool
 	MediaClientUrl          string
 	MediaClientAccessToken  string
-	AdminContacts           []*config.SupportContact
-	SecurityContacts        []*config.SupportContact
+	AdminContacts           []config.SupportContact
+	SecurityContacts        []config.SupportContact
 	SupportUrl              string
 }
 
@@ -58,8 +58,8 @@ type Homeserver struct {
 	stateLearnCache        *cache.Cache[string, bool] // room ID -> literally anything because we don't really care about the value
 	mediaClientUrl         string
 	mediaClientAccessToken string
-	adminContacts          []*config.SupportContact
-	securityContacts       []*config.SupportContact
+	adminContacts          []config.SupportContact
+	securityContacts       []config.SupportContact
 	supportUrl             string
 }
 


### PR DESCRIPTION
Turns out I didn't manually test the `PS_SUPPORT_(ADMIN|SECURITY)_CONTACTS` environment variables 🙈 I also missed the decoder documentation saying it needed to set the pointer rather than populate it: https://github.com/kelseyhightower/envconfig?tab=readme-ov-file#custom-decoders (`*ipd = <thing>` instead of `ipd.Val = <thing>`).

To make it work, we also need to use non-reference structs in the `config` and elsewhere. I'm not entirely clear on why, but it explodes with the same error if we fail to do that.

### The error

```
panic: runtime error: invalid memory address or nil pointer dereference
[signal SIGSEGV: segmentation violation code=0x1 addr=0x8 pc=0x7bc4f3]
goroutine 1 [running]:
github.com/matrix-org/policyserv/config.(*SupportContact).Decode(0x0, {0xc0000386aa, 0x10})
	/opt/config/support_contacts.go:27 +0x53
github.com/kelseyhightower/envconfig.processField({0xc0000386aa, 0x10}, {0xe0ed40?, 0xc0001223f0?, 0x0?})
	/go/pkg/mod/github.com/kelseyhightower/envconfig@v1.4.0/envconfig.go:242 +0xad3
github.com/kelseyhightower/envconfig.processField({0xc0000386aa, 0x10}, {0xda9640?, 0xc0001fc218?, 0x41897e?})
	/go/pkg/mod/github.com/kelseyhightower/envconfig@v1.4.0/envconfig.go:312 +0xb65
github.com/kelseyhightower/envconfig.Process({0x1007d1d?, 0x0?}, {0xd95d60?, 0xc0001fc008?})
	/go/pkg/mod/github.com/kelseyhightower/envconfig@v1.4.0/envconfig.go:215 +0x2cc
github.com/matrix-org/policyserv/config.NewInstanceConfig(...)
	/opt/config/config.go:66
main.main()
	/opt/cmd/app/main.go:32 +0x68
```

### Pull Request Checklist

<!-- Please read https://github.com/matrix-org/policyserv/CONTRIBUTING.md before submitting your pull request -->

* [x] Pull request is based on the `main` branch.
* [x] Pull request title describes the changes in a way a user would understand. For example, "Fix keywords filter not applying" instead of "Read keywords slice in a loop".
* [x] Code style matches surrounding code.
* [x] Tests are added for new code (and existing code) if possible.
  * If not possible, please explain why in your PR description. 
* [x] The CI checks pass.
