### PR TITLE
Handle invalid user IDs even better

### DIFF
--- a/filter/filter_untrusted_media.go
+++ b/filter/filter_untrusted_media.go
@@ -75,10 +75,6 @@ func (f *InstancedUntrustedMediaFilter) Name() string {
 }
 
 func (f *InstancedUntrustedMediaFilter) CheckEvent(ctx context.Context, input *EventInput) ([]classification.Classification, error) {
-	if !input.Event.SenderID().IsUserID() {
-		return nil, nil // unable to form an opinion on this event
-	}
-
 	userId := input.Event.SenderID().ToUserID().String()
 	isTrusted := false
 	for _, source := range f.trustSources {

--- a/homeserver/api_msc4284_check.go
+++ b/homeserver/api_msc4284_check.go
@@ -6,13 +6,13 @@ import (
 	"net/http"
 	"time"
 
+	"github.com/matrix-org/gomatrixserverlib"
+	"github.com/matrix-org/gomatrixserverlib/fclient"
+	"github.com/matrix-org/gomatrixserverlib/spec"
 	"github.com/matrix-org/policyserv/metrics"
 	"github.com/matrix-org/policyserv/queue"
 	"github.com/matrix-org/policyserv/redaction"
 	"github.com/matrix-org/policyserv/storage"
-	"github.com/matrix-org/gomatrixserverlib"
-	"github.com/matrix-org/gomatrixserverlib/fclient"
-	"github.com/matrix-org/gomatrixserverlib/spec"
 )
 
 var msc4284NeutralResponse = []byte(`{"recommendation": "ok"}`) // MSC4284 uses the word "ok" to mean neutral.
@@ -86,7 +86,10 @@ func httpMSC4284Check(server *Homeserver, w http.ResponseWriter, r *http.Request
 	if res.IsProbablySpam {
 		senderDomain := spec.ServerName("example.org")
 		if event.SenderID().IsUserID() {
-			senderDomain = event.SenderID().ToUserID().Domain()
+			uid := event.SenderID().ToUserID()
+			if uid != nil {
+				senderDomain = uid.Domain()
+			}
 		}
 		if senderDomain != fedReq.Origin() {
 			for _, origin := range server.trustedOrigins {

--- a/redaction/queue.go
+++ b/redaction/queue.go
@@ -6,10 +6,10 @@ import (
 	"log"
 	"time"
 
+	"github.com/matrix-org/gomatrixserverlib"
 	"github.com/matrix-org/policyserv/config"
 	"github.com/matrix-org/policyserv/metrics"
 	"github.com/matrix-org/policyserv/storage"
-	"github.com/matrix-org/gomatrixserverlib"
 	"github.com/panjf2000/ants/v2"
 )
 
@@ -50,7 +50,7 @@ func MakePool(instanceConfig *config.InstanceConfig) {
 func QueueRedaction(storage storage.PersistentStorage, event gomatrixserverlib.PDU) error {
 	metrics.RecordModerationRequest(metrics.ModerationActionRedaction)
 
-	if !event.SenderID().IsUserID() {
+	if !event.SenderID().IsUserID() || event.SenderID().ToUserID() == nil {
 		log.Printf("Non-user sender '%s' in %s at %s", event.SenderID(), event.RoomID().String(), event.EventID())
 		return nil
 	}

--- a/trust/source_creator.go
+++ b/trust/source_creator.go
@@ -83,7 +83,7 @@ func (s *CreatorSource) ImportData(ctx context.Context, roomId string, createEve
 	}
 
 	// Sanity check, because sometimes this goes wrong
-	if !createEvent.SenderID().IsUserID() {
+	if !createEvent.SenderID().IsUserID() || createEvent.SenderID().ToUserID() == nil {
 		return errors.New("sender is not a user ID for unknown reason")
 	}
 


### PR DESCRIPTION
We previously fixed a bug where user ID handling wasn't perfect. This improves it further by checking more of the GMSL code paths, and making the check happen *very* early in the event check code. This allows filters to drop their custom handling. We also copy the behaviour across the rest of the user ID validation sites for safety.

Fixes https://github.com/matrix-org/policyserv/issues/82

We're trying to validate this GMSL path specifically, which swallows errors: https://github.com/matrix-org/gomatrixserverlib/blob/20c9de33969e2df883eaa69c283d6a38efce9284/spec/senderid.go#L72

Tests aren't added for this because we can't mock the data without fighting that very code path.

### Pull Request Checklist

<!-- Please read https://github.com/matrix-org/policyserv/CONTRIBUTING.md before submitting your pull request -->

* [x] Pull request is based on the `main` branch.
* [x] Pull request title describes the changes in a way a user would understand. For example, "Fix keywords filter not applying" instead of "Read keywords slice in a loop".
* [x] Code style matches surrounding code.
* [x] Tests are added for new code (and existing code) if possible.
  * If not possible, please explain why in your PR description. 
* [x] The CI checks pass.
