### PR TITLE
Cache HMA match results per community

### DIFF
--- a/filter/filter_media_scanning.go
+++ b/filter/filter_media_scanning.go
@@ -2,6 +2,7 @@ package filter
 
 import (
 	"context"
+	"database/sql"
 	"errors"
 	"log"
 	"net/http"
@@ -12,6 +13,7 @@ import (
 	"github.com/matrix-org/policyserv/content"
 	"github.com/matrix-org/policyserv/filter/classification"
 	"github.com/matrix-org/policyserv/media"
+	"github.com/matrix-org/policyserv/storage"
 )
 
 const MediaScanningFilterName = "MediaScanningFilter"
@@ -87,6 +89,16 @@ func (f *InstancedMediaScanningFilter) CheckEvent(ctx context.Context, input *Ev
 }
 
 func (f *InstancedMediaScanningFilter) scanMedia(ctx context.Context, event gomatrixserverlib.PDU, media *media.Item, ch chan<- []classification.Classification) {
+	cached, err := f.set.storage.GetMediaClassification(ctx, media.String(), f.set.communityId)
+	if err != nil && !errors.Is(err, sql.ErrNoRows) {
+		log.Printf("[%s | %s] Non-fatal error getting cached media classification: %s", event.EventID(), event.RoomID().String(), err)
+	}
+	if err == nil {
+		log.Printf("[%s | %s] Using cached media classification for %s (%v)", event.EventID(), event.RoomID().String(), media, cached.Classifications)
+		ch <- cached.Classifications
+		return
+	}
+
 	log.Printf("[%s | %s] Downloading media %s", event.EventID(), event.RoomID().String(), media)
 	b, err := media.Download()
 	if err != nil {
@@ -110,5 +122,19 @@ func (f *InstancedMediaScanningFilter) scanMedia(ctx context.Context, event goma
 
 	log.Printf("[%s | %s] Media scan result on %s: %v", event.EventID(), event.RoomID().String(), media, res)
 
+	err = f.set.storage.UpsertMediaClassification(ctx, &storage.StoredMediaClassification{
+		MxcUri:          media.String(),
+		CommunityId:     f.set.communityId,
+		Classifications: res,
+	})
+	if err != nil {
+		log.Printf("[%s | %s] Non-fatal error caching media classification: %s", event.EventID(), event.RoomID().String(), err)
+	}
+
+	err = ctx.Err()
+	if err != nil && (errors.Is(err, context.DeadlineExceeded) || errors.Is(err, context.Canceled)) {
+		// don't try to send on what is about to be a closed channel
+		return
+	}
 	ch <- res
 }

--- a/filter/filter_media_scanning_test.go
+++ b/filter/filter_media_scanning_test.go
@@ -42,11 +42,13 @@ func TestMediaScanningFilter(t *testing.T) {
 	scanner.Expect(content.TypePhoto, spammyBytes, []classification.Classification{classification.CSAM, classification.Spam}, nil)
 	scanner.Expect(content.TypePhoto, neutralBytes, []classification.Classification{classification.CSAM}, nil)
 
-	spammyMxcUri := "mxc://example.org/spam"
+	spammyMxcUri1 := "mxc://example.org/spam1"
+	spammyMxcUri2 := "mxc://example.org/spam2"
 	neutralMxcUri := "mxc://example.org/neutral"
 
 	downloader := test.MustMakeMediaDownloader(t).
-		Set("example.org", "spam", spammyBytes).
+		Set("example.org", "spam1", spammyBytes).
+		Set("example.org", "spam2", spammyBytes).
 		Set("example.org", "neutral", neutralBytes)
 
 	spammyEvent1 := test.MustMakePDU(&test.BaseClientEvent{
@@ -54,7 +56,7 @@ func TestMediaScanningFilter(t *testing.T) {
 		RoomId:  "!foo:example.org",
 		Type:    "org.example.the_event_type_doesnt_matter_in_this_test",
 		Content: map[string]any{
-			"url": spammyMxcUri,
+			"url": spammyMxcUri1,
 		},
 	})
 	spammyEvent2 := test.MustMakePDU(&test.BaseClientEvent{
@@ -63,8 +65,16 @@ func TestMediaScanningFilter(t *testing.T) {
 		Type:    "org.example.the_event_type_doesnt_matter_in_this_test",
 		Content: map[string]any{
 			"info": map[string]any{
-				"thumbnail_url": spammyMxcUri,
+				"thumbnail_url": spammyMxcUri2,
 			},
+		},
+	})
+	spammyEvent3 := test.MustMakePDU(&test.BaseClientEvent{
+		EventId: "$spam3",
+		RoomId:  "!foo:example.org",
+		Type:    "org.example.the_event_type_doesnt_matter_in_this_test",
+		Content: map[string]any{
+			"url": spammyMxcUri2, // repeat the same MXC URI we've already seen to ensure caches work
 		},
 	})
 	neutralEvent1 := test.MustMakePDU(&test.BaseClientEvent{
@@ -81,16 +91,16 @@ func TestMediaScanningFilter(t *testing.T) {
 		Type:    "org.example.the_event_type_doesnt_matter_in_this_test",
 		Content: map[string]any{
 			"info": map[string]any{
-				"thumbnail_url": neutralMxcUri,
+				"thumbnail_url": neutralMxcUri, // also should be cached
 			},
 		},
 	})
 
-	assertSpamVector := func(event gomatrixserverlib.PDU, isSpam bool) {
+	assertSpamVector := func(event gomatrixserverlib.PDU, isSpam bool, expectedDownloadCalls int) {
 		before := downloader.DownloadCalls
 		vecs, err := set.CheckEvent(context.Background(), event, downloader)
 		assert.NoError(t, err)
-		assert.Equal(t, before+1, downloader.DownloadCalls)
+		assert.Equal(t, before+expectedDownloadCalls, downloader.DownloadCalls)
 		assert.Equal(t, 1.0, vecs.GetVector(classification.CSAM)) // always set regardless of spam/neutral
 		if isSpam {
 			assert.Equal(t, 1.0, vecs.GetVector(classification.Spam))
@@ -99,10 +109,11 @@ func TestMediaScanningFilter(t *testing.T) {
 			assert.Equal(t, 0.5, vecs.GetVector(classification.Spam))
 		}
 	}
-	assertSpamVector(spammyEvent1, true)
-	assertSpamVector(spammyEvent2, true)
-	assertSpamVector(neutralEvent1, false)
-	assertSpamVector(neutralEvent2, false)
+	assertSpamVector(spammyEvent1, true, 1)
+	assertSpamVector(spammyEvent2, true, 1)
+	assertSpamVector(spammyEvent3, true, 0) // should have cached the result in spammyEvent2
+	assertSpamVector(neutralEvent1, false, 1)
+	assertSpamVector(neutralEvent2, false, 0) // should have been cached above too
 }
 
 func TestMediaScanningFilterClassifiesAsUnsafeOnScanError(t *testing.T) {

--- a/migrations/16_add_media_scan_cache_down.sql
+++ b/migrations/16_add_media_scan_cache_down.sql
@@ -1,0 +1,1 @@
+DROP TABLE media_classifications;

--- a/migrations/16_add_media_scan_cache_up.sql
+++ b/migrations/16_add_media_scan_cache_up.sql
@@ -1,0 +1,6 @@
+CREATE TABLE media_classifications (
+    mxc_uri TEXT NOT NULL,
+    community_id TEXT NOT NULL CONSTRAINT fk_media_classifications_community_id_communities_id REFERENCES communities(id),
+    classifications JSONB NULL,
+    PRIMARY KEY (mxc_uri, community_id)
+);

--- a/storage/interface.go
+++ b/storage/interface.go
@@ -2,8 +2,11 @@ package storage
 
 import (
 	"context"
+	"database/sql/driver"
+	"encoding/json"
 
 	"github.com/matrix-org/policyserv/config"
+	"github.com/matrix-org/policyserv/filter/classification"
 	"github.com/matrix-org/policyserv/filter/confidence"
 )
 
@@ -38,6 +41,31 @@ type StateLearnQueueItem struct {
 type StoredKeywordTemplate struct {
 	Name string `json:"name"`
 	Body string `json:"body"`
+}
+
+type StoredMediaClassification struct {
+	MxcUri          string
+	CommunityId     string
+	Classifications StoredClassifications
+}
+
+// StoredClassifications implements the SQL driver interface for scanning/setting values. Note that the
+// Value() and Scan() functions are on different receivers - this is because the Value() is not going to
+// be on a pointer (see StoredMediaClassification), but Scan() will always be called on a pointer. If Scan()
+// was changed to use a value (non-pointer) receiver instead, the value we read from the database would never
+// actually leave the function call, confusing the calling code.
+type StoredClassifications []classification.Classification
+
+func (c StoredClassifications) Value() (driver.Value, error) {
+	return json.Marshal(c)
+}
+
+func (c *StoredClassifications) Scan(src interface{}) error {
+	b, ok := src.([]byte)
+	if !ok {
+		return nil
+	}
+	return json.Unmarshal(b, &c)
 }
 
 type Transaction interface { // mirror of sql.Tx interface for ease of compatibility
@@ -85,4 +113,7 @@ type PersistentStorage interface {
 
 	UpsertKeywordTemplate(ctx context.Context, template *StoredKeywordTemplate) error
 	GetKeywordTemplate(ctx context.Context, name string) (*StoredKeywordTemplate, error)
+
+	UpsertMediaClassification(ctx context.Context, classification *StoredMediaClassification) error
+	GetMediaClassification(ctx context.Context, mxcUri string, communityId string) (*StoredMediaClassification, error)
 }

--- a/storage/psql.go
+++ b/storage/psql.go
@@ -58,6 +58,8 @@ type PostgresStorage struct {
 	trustDataUpsert                      *sql.Stmt
 	keywordTemplateSelect                *sql.Stmt
 	keywordTemplateUpsert                *sql.Stmt
+	mediaClassificationSelect            *sql.Stmt
+	mediaClassificationUpsert            *sql.Stmt
 
 	//userIdsAndDisplayNamesByRoomIdUpsert *sql.Stmt // We do the upsert manually to enter a transaction instead
 	//banRulesUpsertForRoom                *sql.Stmt // We do the upsert manually to enter a transaction instead
@@ -152,6 +154,12 @@ func (s *PostgresStorage) prepare(migrationsDir string) error {
 		return err
 	}
 	if s.keywordTemplateUpsert, err = s.db.Prepare("INSERT INTO keyword_templates (name, body) VALUES ($1, $2) ON CONFLICT (name) DO UPDATE SET body = $2;"); err != nil {
+		return err
+	}
+	if s.mediaClassificationSelect, err = s.readonlyDb.Prepare("SELECT mxc_uri, community_id, classifications FROM media_classifications WHERE mxc_uri = $1 AND community_id = $2;"); err != nil {
+		return err
+	}
+	if s.mediaClassificationUpsert, err = s.db.Prepare("INSERT INTO media_classifications (mxc_uri, community_id, classifications) VALUES ($1, $2, $3) ON CONFLICT (mxc_uri, community_id) DO UPDATE SET classifications = $3;"); err != nil {
 		return err
 	}
 
@@ -533,6 +541,27 @@ func (s *PostgresStorage) GetKeywordTemplate(ctx context.Context, name string) (
 	r := s.keywordTemplateSelect.QueryRowContext(ctx, name)
 	val := &StoredKeywordTemplate{}
 	err := r.Scan(&val.Name, &val.Body)
+	if err != nil {
+		return nil, err
+	}
+	return val, nil
+}
+
+func (s *PostgresStorage) UpsertMediaClassification(ctx context.Context, mediaClassification *StoredMediaClassification) error {
+	t := dbmetrics.StartSelfDatabaseTimer("UpsertMediaClassification")
+	defer t.ObserveDuration()
+
+	_, err := s.mediaClassificationUpsert.ExecContext(ctx, mediaClassification.MxcUri, mediaClassification.CommunityId, mediaClassification.Classifications)
+	return err
+}
+
+func (s *PostgresStorage) GetMediaClassification(ctx context.Context, mxcUri string, communityId string) (*StoredMediaClassification, error) {
+	t := dbmetrics.StartSelfDatabaseTimer("GetMediaClassification")
+	defer t.ObserveDuration()
+
+	r := s.mediaClassificationSelect.QueryRowContext(ctx, mxcUri, communityId)
+	val := &StoredMediaClassification{}
+	err := r.Scan(&val.MxcUri, &val.CommunityId, &val.Classifications)
 	if err != nil {
 		return nil, err
 	}

--- a/test/memory_storage.go
+++ b/test/memory_storage.go
@@ -30,6 +30,7 @@ type MemoryStorage struct {
 	pendingLearnStateQueue []*storage.StateLearnQueueItem
 	trustData              map[string]map[string][]byte // sourceName -> key -> JSON value
 	keywordTemplates       map[string]*storage.StoredKeywordTemplate
+	mediaClassifications   map[string]map[string]*storage.StoredMediaClassification // mxcUri -> communityId -> classification
 }
 
 func NewMemoryStorage(t *testing.T) *MemoryStorage {
@@ -44,6 +45,7 @@ func NewMemoryStorage(t *testing.T) *MemoryStorage {
 		pendingLearnStateQueue: make([]*storage.StateLearnQueueItem, 0),
 		trustData:              make(map[string]map[string][]byte),
 		keywordTemplates:       make(map[string]*storage.StoredKeywordTemplate),
+		mediaClassifications:   make(map[string]map[string]*storage.StoredMediaClassification),
 	}
 }
 
@@ -251,6 +253,30 @@ func (m *MemoryStorage) GetKeywordTemplate(ctx context.Context, name string) (*s
 func (m *MemoryStorage) UpsertKeywordTemplate(ctx context.Context, template *storage.StoredKeywordTemplate) error {
 	assert.NotNil(m.t, ctx, "context is required")
 	m.keywordTemplates[template.Name] = template
+	return nil
+}
+
+func (m *MemoryStorage) GetMediaClassification(ctx context.Context, mxcUri string, communityId string) (*storage.StoredMediaClassification, error) {
+	assert.NotNil(m.t, ctx, "context is required")
+
+	byCommunity, ok := m.mediaClassifications[mxcUri]
+	if !ok {
+		return nil, sql.ErrNoRows
+	}
+	val, ok := byCommunity[communityId]
+	if !ok {
+		return nil, sql.ErrNoRows
+	}
+	return val, nil
+}
+
+func (m *MemoryStorage) UpsertMediaClassification(ctx context.Context, classification *storage.StoredMediaClassification) error {
+	assert.NotNil(m.t, ctx, "context is required")
+
+	if m.mediaClassifications[classification.MxcUri] == nil {
+		m.mediaClassifications[classification.MxcUri] = make(map[string]*storage.StoredMediaClassification)
+	}
+	m.mediaClassifications[classification.MxcUri][classification.CommunityId] = classification
 	return nil
 }
 


### PR DESCRIPTION
We only cache the high level MXC URI result on a per community basis because the underlying HMA content banks might (legitimately) change their mind about a particular hash. We also store this on a per-community basis because communities might be using different content banks.

Fixes https://github.com/matrix-org/policyserv/issues/34

### Pull Request Checklist

<!-- Please read https://github.com/matrix-org/policyserv/CONTRIBUTING.md before submitting your pull request -->

* [x] Pull request is based on the `main` branch.
* [x] Pull request title describes the changes in a way a user would understand. For example, "Fix keywords filter not applying" instead of "Read keywords slice in a loop".
* [x] Code style matches surrounding code.
* [x] Tests are added for new code (and existing code) if possible.
  * If not possible, please explain why in your PR description. 
* [x] The CI checks pass.

