### PR TITLE
Support sending redaction commands to community-specified moderation bots

### DIFF
--- a/README.md
+++ b/README.md
@@ -122,6 +122,9 @@ server are trusted by the server administrator(s).
 * `PS_SPAM_THRESHOLD` (default `0.8`) - A value between 0 and 1 denoting how much "confidence" is needed before an event 
   is considered spammy. Note that policyserv can currently only generate scores of 0, 0.5, and 1 - a future version will 
   allow for more precise scores, so it's recommended to keep this value as a decimal.
+* `PS_MODERATION_BOT_USER_ID` (default empty value) - The user ID of the bot account where policyserv can send redaction
+  commands to. A device on the user *must* implement the [policyserv to-device protocol](./docs/to_device.md) for this to
+  work. Set to an empty value to disable this feature.
 
 ### Allowed senders prefilter
 

--- a/config/community.go
+++ b/config/community.go
@@ -47,6 +47,7 @@ type CommunityConfig struct {
 	UnsafeSigningKeyFilterEnabled            bool      `json:"unsafe_signing_key_filter_enabled,omitempty" envconfig:"unsafe_signing_key_filter_enabled" default:"true"`
 	FrequencyFilterEventTypes                *[]string `json:"frequency_filter_event_types,omitempty" envconfig:"frequency_filter_event_types" default:"m.room.message,m.sticker,m.reaction"`
 	FrequencyFilterRateLimit                 *float64  `json:"frequency_filter_rate_limit,omitempty" envconfig:"frequency_filter_rate_limit" default:"0"`
+	ModerationBotUserId                      *string   `json:"moderation_bot_user_id,omitempty" envconfig:"moderation_bot_user_id" default:""`
 }
 
 func (c *CommunityConfig) Clone() (*CommunityConfig, error) {

--- a/docs/to_device.md
+++ b/docs/to_device.md
@@ -1,0 +1,54 @@
+# To-device Messaging Protocol
+
+When a policyserv community sets their `moderation_bot_user_id` configuration option, policyserv will send to-device messages
+to that user ID for some actions. The user doesn't *need* to be a moderation bot, but it typically is.
+
+All to-device messages sent by policyserv are "fire and forget", meaning policyserv does not wait for a success or error
+response. It is the responsibility of the receiving user to handle retries (if they want to) or to ignore messages that
+were sent a while ago (also if they want to).
+
+## Message format
+
+The general format for a to-device message sent by policyserv is:
+
+```json5
+{
+  "type": "org.matrix.policyserv.command",
+  "content": {
+    "command": "<whatever>",
+    "room_id": "<room ID>", // the room where this command applies
+    // ... other fields as required ...
+    "signatures": {
+      "policy.example.org": {
+        "ed25519:policy_server": "<unpadded base64 signature>"
+      }
+    }
+  }
+}
+```
+
+The signature covers the entire `content` field, using normal [Matrix signing](https://spec.matrix.org/v1.18/appendices/#signing-json).
+The public key used to sign the message will be the one stored in the [`m.room.policy`](https://spec.matrix.org/v1.18/client-server-api/#mroompolicy)
+state event in the protected room.
+
+Receivers MUST verify the signature before processing the command. If *any* of the signatures are invalid, or if the room's
+policy server has *not* signed the message, the message MUST be ignored (dropped).
+
+## Commands
+
+Currently, policyserv only supports the `redact` command.
+
+### Redaction
+
+Policyserv sends this command when it believes a spammy event has leaked into a room and should be redacted as a result.
+
+Example content:
+
+```json5
+{
+  "command": "redact",
+  "room_id": "!room:example.org", // the room where the event resides
+  "event_id": "$event", // the event to redact in the room
+  "signatures": { /* ... */ }
+}
+```

--- a/homeserver/api_msc4284_check.go
+++ b/homeserver/api_msc4284_check.go
@@ -11,7 +11,6 @@ import (
 	"github.com/matrix-org/gomatrixserverlib/spec"
 	"github.com/matrix-org/policyserv/metrics"
 	"github.com/matrix-org/policyserv/queue"
-	"github.com/matrix-org/policyserv/redaction"
 	"github.com/matrix-org/policyserv/storage"
 )
 
@@ -84,24 +83,7 @@ func httpMSC4284Check(server *Homeserver, w http.ResponseWriter, r *http.Request
 	}
 
 	if res.IsProbablySpam {
-		senderDomain := spec.ServerName("example.org")
-		if event.SenderID().IsUserID() {
-			uid := event.SenderID().ToUserID()
-			if uid != nil {
-				senderDomain = uid.Domain()
-			}
-		}
-		if senderDomain != fedReq.Origin() {
-			for _, origin := range server.trustedOrigins {
-				if fedReq.Origin() == spec.ServerName(origin) {
-					err = redaction.QueueRedaction(server.storage, event)
-					if err != nil {
-						log.Printf("Non-fatal error trying to submit redaction for spammy event %s in %s: %s", event.EventID(), event.RoomID().String(), err)
-					}
-					break
-				}
-			}
-		}
+		redactIfNeeded(r.Context(), server, fedReq.Origin(), event)
 	}
 
 	defer metrics.RecordHttpResponse(r.Method, "httpMSC4284Check", http.StatusOK)

--- a/homeserver/api_msc4284_sign.go
+++ b/homeserver/api_msc4284_sign.go
@@ -1,6 +1,7 @@
 package homeserver
 
 import (
+	"context"
 	"encoding/json"
 	"log"
 	"net/http"
@@ -67,6 +68,7 @@ func handlePolicySignRequest(server *Homeserver, w http.ResponseWriter, r *http.
 	if err != nil {
 		log.Println("Error submitting event:", err)
 		refuseToSign(w, r, stable)
+		redactIfNeeded(r.Context(), server, fedReq.Origin(), event)
 		return
 	}
 
@@ -84,17 +86,41 @@ func handlePolicySignRequest(server *Homeserver, w http.ResponseWriter, r *http.
 	if res.Err != nil {
 		log.Println("Error receiving event result:", err)
 		refuseToSign(w, r, stable)
+		redactIfNeeded(r.Context(), server, fedReq.Origin(), event)
 		return
 	}
 
 	if res.IsProbablySpam {
 		log.Printf("🚫 [%s] refusing to sign in %s", event.EventID(), event.RoomID().String())
 		refuseToSign(w, r, stable)
+		redactIfNeeded(r.Context(), server, fedReq.Origin(), event)
 		return
 	}
 
 	signEvent(server, event, w)
 	log.Printf("✅ [%s] Signed in %s as requested by %s", event.EventID(), event.RoomID().String(), fedReq.Origin())
+}
+
+func redactIfNeeded(ctx context.Context, server *Homeserver, requestOrigin spec.ServerName, event gomatrixserverlib.PDU) {
+	// We need to be a bit careful with invalid user IDs here. If things are invalid, we'll try to redact the event
+	// as a precaution.
+	senderDomain := spec.ServerName("undefined.invalid")
+	if event.SenderID().IsUserID() && event.SenderID().ToUserID() != nil {
+		senderDomain = event.SenderID().ToUserID().Domain()
+	}
+
+	// If the sender and requesting domain are the same, we're assuming that the server will reject the event. If not,
+	// then we'll either see the event over `/send` (where the requestOrigin will be nil-like) or from another server
+	// re-checking the event. *Then* we'll redact it.
+	if senderDomain == requestOrigin {
+		log.Printf("[%s | %s] Sender and requesting domain are the same - assuming they rejected the event.", event.EventID(), event.RoomID().String())
+		return
+	}
+
+	err := server.SendRedactInstruction(ctx, event)
+	if err != nil {
+		log.Printf("[%s | %s] Non-fatal error trying to submit redaction for event", event.EventID(), event.RoomID().String())
+	}
 }
 
 func refuseToSign(w http.ResponseWriter, r *http.Request, stable bool) {

--- a/homeserver/api_transactions.go
+++ b/homeserver/api_transactions.go
@@ -7,11 +7,12 @@ import (
 	"net/http"
 	"time"
 
-	"github.com/matrix-org/policyserv/metrics"
-	"github.com/matrix-org/policyserv/storage"
 	"github.com/matrix-org/gomatrixserverlib"
 	"github.com/matrix-org/gomatrixserverlib/fclient"
 	"github.com/matrix-org/gomatrixserverlib/spec"
+	"github.com/matrix-org/policyserv/metrics"
+	"github.com/matrix-org/policyserv/queue"
+	"github.com/matrix-org/policyserv/storage"
 )
 
 type eventRoomIdOnly struct {
@@ -109,14 +110,37 @@ func httpTransactionReceive(server *Homeserver, w http.ResponseWriter, r *http.R
 
 		// *Now* we can queue the event for checking
 		// Note: we use a background context instead of request context because the request might finish before the
-		// event is run through the filters. We don't want to do that forever though.
-		ctx, cancel := context.WithTimeout(context.Background(), 2*time.Minute)
-		defer cancel()
-		err = server.runFilters(ctx, event, nil)
-		if err != nil {
-			log.Printf("Error queueing event %s: %s", event.EventID(), err)
-			continue
-		}
+		// event is run through the filters. We don't want to do that forever though. We also async the check because
+		// we don't really need to block the request on each event getting checked individually.
+		go func() {
+			ctx, cancel := context.WithTimeout(context.Background(), 2*time.Minute)
+			defer cancel()
+
+			ch := make(chan *queue.PoolResult, 1) // use a buffered channel to reduce deadlock potential
+			defer close(ch)
+			err = server.runFilters(ctx, event, ch)
+			if err != nil {
+				log.Printf("Error queueing event %s: %s", event.EventID(), err)
+				return
+			}
+
+			var res *queue.PoolResult
+			select {
+			case res = <-ch:
+			case <-ctx.Done():
+				log.Printf("[%s | %s] Request context cancelled: %s", event.EventID(), event.RoomID().String(), r.Context().Err())
+				return
+			}
+
+			if res.Err != nil {
+				log.Printf("[%s | %s] Error processing event: %s", event.EventID(), event.RoomID().String(), res.Err)
+				return
+			}
+
+			if res.IsProbablySpam {
+				redactIfNeeded(ctx, server, "not_a_real_server_to_always_fail_the_included_sender_check", event)
+			}
+		}()
 	}
 
 	// Don't forget to actually reply too

--- a/homeserver/todevice_redaction.go
+++ b/homeserver/todevice_redaction.go
@@ -1,0 +1,106 @@
+package homeserver
+
+import (
+	"context"
+	"encoding/json"
+	"log"
+
+	"github.com/matrix-org/gomatrixserverlib"
+	"github.com/matrix-org/gomatrixserverlib/spec"
+	"github.com/matrix-org/policyserv/internal"
+	"github.com/matrix-org/policyserv/redaction"
+	"github.com/matrix-org/policyserv/storage"
+)
+
+func (h *Homeserver) SendRedactInstruction(ctx context.Context, forEvent gomatrixserverlib.PDU) error {
+	log.Printf("[%s | %s] Redaction command requested for event", forEvent.EventID(), forEvent.RoomID().String())
+
+	// Backwards compatibility first:
+	err := redaction.QueueRedaction(h.storage, forEvent)
+	if err != nil {
+		log.Printf("[%s | %s] Non-fatal error trying to submit backwards-compatible redaction for event", forEvent.EventID(), forEvent.RoomID().String())
+	}
+
+	// Now onto the new stuff: find the community and their moderation bot's user ID, then send that user a to-device
+	// message to instruct them to redact the event.
+	room, err := h.storage.GetRoom(ctx, forEvent.RoomID().String())
+	if err != nil {
+		log.Printf("[%s | %s] Failed to get room information: %s", forEvent.EventID(), forEvent.RoomID().String(), err)
+		return err
+	}
+	if room == nil {
+		log.Printf("[%s | %s] No room found - skipping redaction", forEvent.EventID(), forEvent.RoomID().String())
+		return nil // no room means no community either, which means no redaction
+	}
+
+	community, err := h.storage.GetCommunity(ctx, room.CommunityId)
+	if err != nil {
+		log.Printf("[%s | %s] Failed to get community information: %s", forEvent.EventID(), forEvent.RoomID().String(), err)
+		return err
+	}
+	if community == nil {
+		log.Printf("[%s | %s] No community found - skipping redaction", forEvent.EventID(), forEvent.RoomID().String())
+		return nil // just like having no room, no community means no redaction
+	}
+
+	modbotUserId := internal.Dereference(community.Config.ModerationBotUserId)
+	if modbotUserId == "" {
+		log.Printf("[%s | %s | %s] No moderation bot user ID found - skipping redaction", forEvent.EventID(), forEvent.RoomID().String(), community.CommunityId)
+		return nil // no moderation bot means no redaction
+	}
+	modbotUserIdParsed, err := spec.NewUserID(modbotUserId, true)
+	if err != nil {
+		log.Printf("[%s | %s | %s] Failed to validate moderation bot user ID: %s", forEvent.EventID(), forEvent.RoomID().String(), community.CommunityId, err)
+		return err
+	}
+
+	// Create the body of the redaction command (we'll need to sign it so the moderation bot can verify it)
+	body, err := json.Marshal(map[string]any{
+		"command":  "redact",
+		"room_id":  forEvent.RoomID().String(),
+		"event_id": forEvent.EventID(),
+	})
+	if err != nil {
+		log.Printf("[%s | %s | %s] Failed to marshal redaction command: %s", forEvent.EventID(), forEvent.RoomID().String(), community.CommunityId, err)
+		return err // "should never happen"
+	}
+	signed, err := gomatrixserverlib.SignJSON(string(h.ServerName), PolicyServerKeyID, h.eventSigningKey, body)
+	if err != nil {
+		log.Printf("[%s | %s | %s] Failed to sign redaction command: %s", forEvent.EventID(), forEvent.RoomID().String(), community.CommunityId, err)
+		return err // "should never happen"
+	}
+
+	// Create the to-device message EDU and send it
+	toDeviceMsg := gomatrixserverlib.ToDeviceMessage{
+		Sender:    h.localActor.String(),
+		Type:      "org.matrix.policyserv.command",
+		MessageID: storage.NextId(),
+		Messages: map[string]map[string]json.RawMessage{
+			modbotUserId: map[string]json.RawMessage{
+				"*": signed,
+			},
+		},
+	}
+	msg, err := json.Marshal(toDeviceMsg)
+	if err != nil {
+		log.Printf("[%s | %s | %s] Failed to marshal to-device message: %s", forEvent.EventID(), forEvent.RoomID().String(), community.CommunityId, err)
+		return err // "should never happen"
+	}
+	edu := &storage.StoredEdu{
+		Destination: string(modbotUserIdParsed.Domain()),
+		Payload: gomatrixserverlib.EDU{
+			Type:    "m.direct_to_device",
+			Content: msg,
+		},
+	}
+	err = h.storage.InsertEdu(ctx, edu)
+	if err != nil {
+		log.Printf("[%s | %s | %s] Failed to insert to-device message EDU: %s", forEvent.EventID(), forEvent.RoomID().String(), community.CommunityId, err)
+		return err
+	}
+	log.Printf("[%s | %s | %s] Queued redaction command to %s", forEvent.EventID(), forEvent.RoomID().String(), community.CommunityId, modbotUserId)
+
+	// inserting will trigger a send (eventually), so we don't need to do that here
+
+	return nil
+}

--- a/homeserver/todevice_redaction_test.go
+++ b/homeserver/todevice_redaction_test.go
@@ -1,0 +1,175 @@
+package homeserver
+
+import (
+	"context"
+	"testing"
+
+	"github.com/matrix-org/gomatrixserverlib"
+	"github.com/matrix-org/policyserv/config"
+	"github.com/matrix-org/policyserv/internal"
+	"github.com/matrix-org/policyserv/storage"
+	"github.com/matrix-org/policyserv/test"
+	"github.com/stretchr/testify/assert"
+	"github.com/tidwall/gjson"
+)
+
+func TestSendRedactInstructionUnknownRoom(t *testing.T) {
+	t.Parallel()
+
+	hs := NewMockServer(t, NoConfigChanges)
+
+	pdu := test.MustMakePDU(&test.BaseClientEvent{
+		Type:   "m.room.message",
+		RoomId: "!room:example.org",
+		Content: map[string]any{
+			"body": "hello world",
+		},
+	})
+
+	// We don't insert the room or community into the database, so the redaction code should treat this
+	// as "unknown".
+
+	err := hs.SendRedactInstruction(context.Background(), pdu)
+	assert.NoError(t, err)
+
+	// If an EDU was inserted, it'll cause the destination to "need catchup".
+	catchupDestinations, err := hs.storage.GetDestinationsNeedingCatchup(context.Background())
+	assert.NoError(t, err)
+	assert.Equal(t, 0, len(catchupDestinations))
+}
+
+func TestSendRedactInstructionUnknownCommunity(t *testing.T) {
+	t.Parallel()
+
+	hs := NewMockServer(t, NoConfigChanges)
+
+	pdu := test.MustMakePDU(&test.BaseClientEvent{
+		Type:   "m.room.message",
+		RoomId: "!room:example.org",
+		Content: map[string]any{
+			"body": "hello world",
+		},
+	})
+
+	err := hs.storage.UpsertRoom(context.Background(), &storage.StoredRoom{
+		RoomId:      pdu.RoomID().String(),
+		RoomVersion: "10",
+		CommunityId: "default",
+	})
+	assert.NoError(t, err)
+
+	// We don't insert the community into the database, so the redaction code should treat this
+	// as "unknown".
+
+	err = hs.SendRedactInstruction(context.Background(), pdu)
+	assert.NoError(t, err)
+
+	// If an EDU was inserted, it'll cause the destination to "need catchup".
+	catchupDestinations, err := hs.storage.GetDestinationsNeedingCatchup(context.Background())
+	assert.NoError(t, err)
+	assert.Equal(t, 0, len(catchupDestinations))
+}
+
+func TestSendRedactInstructionCommunityNoModerationBot(t *testing.T) {
+	t.Parallel()
+
+	hs := NewMockServer(t, NoConfigChanges)
+
+	pdu := test.MustMakePDU(&test.BaseClientEvent{
+		Type:   "m.room.message",
+		RoomId: "!room:example.org",
+		Content: map[string]any{
+			"body": "hello world",
+		},
+	})
+
+	err := hs.storage.UpsertRoom(context.Background(), &storage.StoredRoom{
+		RoomId:      pdu.RoomID().String(),
+		RoomVersion: "10",
+		CommunityId: "default",
+	})
+	assert.NoError(t, err)
+
+	err = hs.storage.UpsertCommunity(context.Background(), &storage.StoredCommunity{
+		CommunityId: "default",
+		Name:        "Testing",
+		Config: &config.CommunityConfig{
+			HellbanPostfilterMinutes: internal.Pointer(-1),
+			ModerationBotUserId:      internal.Pointer(""), // no moderation bot
+		},
+	})
+
+	err = hs.SendRedactInstruction(context.Background(), pdu)
+	assert.NoError(t, err)
+
+	// If an EDU was inserted, it'll cause the destination to "need catchup".
+	catchupDestinations, err := hs.storage.GetDestinationsNeedingCatchup(context.Background())
+	assert.NoError(t, err)
+	assert.Equal(t, 0, len(catchupDestinations))
+}
+
+func TestSendRedactInstruction(t *testing.T) {
+	t.Parallel()
+
+	hs := NewMockServer(t, NoConfigChanges)
+
+	pdu := test.MustMakePDU(&test.BaseClientEvent{
+		EventId: "$redact_me",
+		Type:    "m.room.message",
+		RoomId:  "!room:example.org",
+		Content: map[string]any{
+			"body": "hello world",
+		},
+	})
+
+	err := hs.storage.UpsertRoom(context.Background(), &storage.StoredRoom{
+		RoomId:      pdu.RoomID().String(),
+		RoomVersion: "10",
+		CommunityId: "default",
+	})
+	assert.NoError(t, err)
+
+	err = hs.storage.UpsertCommunity(context.Background(), &storage.StoredCommunity{
+		CommunityId: "default",
+		Name:        "Testing",
+		Config: &config.CommunityConfig{
+			HellbanPostfilterMinutes: internal.Pointer(-1),
+			ModerationBotUserId:      internal.Pointer("@user:example.org"),
+		},
+	})
+
+	err = hs.SendRedactInstruction(context.Background(), pdu)
+	assert.NoError(t, err)
+
+	// If an EDU was inserted, it'll cause the destination to "need catchup".
+	catchupDestinations, err := hs.storage.GetDestinationsNeedingCatchup(context.Background())
+	assert.NoError(t, err)
+	assert.Equal(t, 1, len(catchupDestinations))
+
+	// Get that EDU so we can verify it
+	mxTxn, sqlTxn, err := hs.storage.BeginMatrixTransaction(context.Background(), catchupDestinations[0])
+	assert.NoError(t, err)
+	assert.NoError(t, sqlTxn.Commit())
+	assert.Equal(t, 1, len(mxTxn.Edus))
+	edu := mxTxn.Edus[0]
+
+	// Verify the EDU shape, starting with the outer to-device carrier type
+	assert.Equal(t, "m.direct_to_device", edu.Type)
+	contentJson := string(edu.Content)
+	assert.Equal(t, "org.matrix.policyserv.command", gjson.Get(contentJson, "type").String())
+	assert.Equal(t, hs.localActor.String(), gjson.Get(contentJson, "sender").String())
+	assert.NotEmpty(t, gjson.Get(contentJson, "message_id").String())
+	messagesMap := gjson.Get(contentJson, "messages").Map()
+	assert.Equal(t, 1, len(messagesMap))
+	assert.Equal(t, 1, len(messagesMap["@user:example.org"].Map()))
+	assert.NotNil(t, messagesMap["@user:example.org"].Map()["*"])
+
+	// Now verify the actual message itself, including signature
+	signedBodyRaw := messagesMap["@user:example.org"].Map()["*"]
+	signedBody := signedBodyRaw.Map()
+	assert.Equal(t, "redact", signedBody["command"].String())
+	assert.Equal(t, pdu.RoomID().String(), signedBody["room_id"].String())
+	assert.Equal(t, pdu.EventID(), signedBody["event_id"].String())
+	err = gomatrixserverlib.VerifyJSON(string(hs.ServerName), PolicyServerKeyID, hs.GetPublicEventSigningKey(), []byte(signedBodyRaw.Raw))
+	assert.NoError(t, err)
+}

--- a/homeserver/todevice_redaction_test.go
+++ b/homeserver/todevice_redaction_test.go
@@ -16,7 +16,7 @@ import (
 func TestSendRedactInstructionUnknownRoom(t *testing.T) {
 	t.Parallel()
 
-	hs := NewMockServer(t, NoConfigChanges)
+	hs := NewMockServerForTest(t, test.NewMemoryStorage(t), NoConfigChanges)
 
 	pdu := test.MustMakePDU(&test.BaseClientEvent{
 		Type:   "m.room.message",
@@ -41,7 +41,7 @@ func TestSendRedactInstructionUnknownRoom(t *testing.T) {
 func TestSendRedactInstructionUnknownCommunity(t *testing.T) {
 	t.Parallel()
 
-	hs := NewMockServer(t, NoConfigChanges)
+	hs := NewMockServerForTest(t, test.NewMemoryStorage(t), NoConfigChanges)
 
 	pdu := test.MustMakePDU(&test.BaseClientEvent{
 		Type:   "m.room.message",
@@ -73,7 +73,7 @@ func TestSendRedactInstructionUnknownCommunity(t *testing.T) {
 func TestSendRedactInstructionCommunityNoModerationBot(t *testing.T) {
 	t.Parallel()
 
-	hs := NewMockServer(t, NoConfigChanges)
+	hs := NewMockServerForTest(t, test.NewMemoryStorage(t), NoConfigChanges)
 
 	pdu := test.MustMakePDU(&test.BaseClientEvent{
 		Type:   "m.room.message",
@@ -111,7 +111,7 @@ func TestSendRedactInstructionCommunityNoModerationBot(t *testing.T) {
 func TestSendRedactInstruction(t *testing.T) {
 	t.Parallel()
 
-	hs := NewMockServer(t, NoConfigChanges)
+	hs := NewMockServerForTest(t, test.NewMemoryStorage(t), NoConfigChanges)
 
 	pdu := test.MustMakePDU(&test.BaseClientEvent{
 		EventId: "$redact_me",

--- a/redaction/queue.go
+++ b/redaction/queue.go
@@ -66,6 +66,9 @@ func QueueRedaction(storage storage.PersistentStorage, event gomatrixserverlib.P
 	if err != nil {
 		return err
 	}
+	if room == nil {
+		return nil // no room == no moderator, so nothing to queue
+	}
 	if room.ModeratorUserId == "" {
 		log.Println("No moderator for room", roomId)
 		metrics.RecordModerationAction(metrics.ModerationActionRedaction, metrics.ModerationStatusNoModerator)


### PR DESCRIPTION
For https://github.com/matrix-org/policyserv/issues/63#issuecomment-4084416026

**Requires https://github.com/matrix-org/policyserv/pull/118** (base for this PR)

In short, this identifies where a redaction might be best placed, then sends the to-device redaction command if it can. 

This also fixes a bug where redactions might not be sent in some cases.

TODO:
* [x] Documentation for bot authors
* [x] Tests
* [x] Limit user IDs to a single community (or find another way to "approve" them) => **Descoped**: for now we just won't add the option to set the moderation bot user ID in policyserv-setup-bot, which means it'll need to be set by the policyserv operator (or their tooling) instead of self-serve by the community. See https://github.com/matrix-org/policyserv/issues/120

### Pull Request Checklist

<!-- Please read https://github.com/matrix-org/policyserv/CONTRIBUTING.md before submitting your pull request -->

* [ ] Pull request is based on the `main` branch.
* [x] Pull request title describes the changes in a way a user would understand. For example, "Fix keywords filter not applying" instead of "Read keywords slice in a loop".
* [x] Code style matches surrounding code.
* [x] Tests are added for new code (and existing code) if possible.
  * If not possible, please explain why in your PR description. 
* [x] The CI checks pass.

