### PR TITLE
Fix "cannot execute SELECT FOR UPDATE in readonly transaction" errors

### DIFF
--- a/storage/psql.go
+++ b/storage/psql.go
@@ -177,7 +177,8 @@ func (s *PostgresStorage) prepare(migrationsDir string) error {
 	// `FOR UPDATE SKIP LOCKED` avoids returning rows that are locked. In our case that lock is coming from BeginMatrixTransaction
 	// which would indicate that the EDUs are currently being sent. Postgres doesn't let us put a `DISTINCT` on that query
 	// though, so we have to subquery it.
-	if s.destinationsNeedingCatchupSelect, err = s.readonlyDb.Prepare("SELECT DISTINCT sub.destination FROM (SELECT destination FROM destination_edus FOR UPDATE SKIP LOCKED) AS sub;"); err != nil {
+	// Note: We can't use the readonly database because `FOR UPDATE` requires write capabilities to establish the lock.
+	if s.destinationsNeedingCatchupSelect, err = s.db.Prepare("SELECT DISTINCT sub.destination FROM (SELECT destination FROM destination_edus FOR UPDATE SKIP LOCKED) AS sub;"); err != nil {
 		return err
 	}
 


### PR DESCRIPTION
Fixes https://github.com/matrix-org/policyserv/issues/124

We don't have tests for this because there are no tests for the postgresql storage (unfortunately). A later PR will add testcontainers support or similar to add some integration tests in the area, hopefully catching issues like this one.

### Pull Request Checklist

<!-- Please read https://github.com/matrix-org/policyserv/CONTRIBUTING.md before submitting your pull request -->

* [x] Pull request is based on the `main` branch.
* [x] Pull request title describes the changes in a way a user would understand. For example, "Fix keywords filter not applying" instead of "Read keywords slice in a loop".
* [x] Code style matches surrounding code.
* [x] Tests are added for new code (and existing code) if possible.
  * If not possible, please explain why in your PR description. 
* [x] The CI checks pass.
