### PR TITLE
Improve reliability of state learning task

### DIFF
--- a/homeserver/homeserver.go
+++ b/homeserver/homeserver.go
@@ -13,6 +13,7 @@ import (
 	"github.com/matrix-org/gomatrixserverlib/fclient"
 	"github.com/matrix-org/gomatrixserverlib/spec"
 	"github.com/matrix-org/policyserv/config"
+	"github.com/matrix-org/policyserv/homeserver/learning"
 	"github.com/matrix-org/policyserv/pubsub"
 	"github.com/matrix-org/policyserv/queue"
 	"github.com/matrix-org/policyserv/storage"
@@ -62,6 +63,7 @@ type Homeserver struct {
 	keyRing                *gomatrixserverlib.KeyRing
 	cacheRoomStateFor      time.Duration
 	trustedOrigins         []string
+	stateLearner           learning.EventStateLearner
 	mediaClientUrl         string
 	mediaClientAccessToken string
 	adminContacts          []config.SupportContact
@@ -111,6 +113,10 @@ func NewHomeserver(config *Config, storage storage.PersistentStorage, pool *queu
 	for i, fetcher := range keyFetchers {
 		keyFetchers[i] = NewExcludeUnsafeKeysFetcher(fetcher)
 	}
+	stateLearner, err := learning.NewRoomStateLearner(storage)
+	if err != nil {
+		return nil, err
+	}
 	hs := &Homeserver{
 		ServerName:             serverName,
 		KeyId:                  keyId,
@@ -136,6 +142,7 @@ func NewHomeserver(config *Config, storage storage.PersistentStorage, pool *queu
 			KeyFetchers: keyFetchers,
 			KeyDatabase: nil, // set to self once created
 		},
+		stateLearner: stateLearner,
 	}
 	hs.keyRing.KeyDatabase = hs // implemented by keyring.go
 

--- a/homeserver/homeserver.go
+++ b/homeserver/homeserver.go
@@ -62,7 +62,6 @@ type Homeserver struct {
 	keyRing                *gomatrixserverlib.KeyRing
 	cacheRoomStateFor      time.Duration
 	trustedOrigins         []string
-	stateLearnCache        *cache.Cache[string, bool] // room ID -> literally anything because we don't really care about the value
 	mediaClientUrl         string
 	mediaClientAccessToken string
 	adminContacts          []config.SupportContact
@@ -137,10 +136,6 @@ func NewHomeserver(config *Config, storage storage.PersistentStorage, pool *queu
 			KeyFetchers: keyFetchers,
 			KeyDatabase: nil, // set to self once created
 		},
-		stateLearnCache: cache.New[string, bool](
-			// We cache entries for ~5 minutes, so clean up somewhat on time
-			cache.WithJanitorInterval[string, bool](5 * time.Minute),
-		),
 	}
 	hs.keyRing.KeyDatabase = hs // implemented by keyring.go
 

--- a/homeserver/learn_state.go
+++ b/homeserver/learn_state.go
@@ -25,12 +25,6 @@ type minimalPolicyRule struct {
 }
 
 func (h *Homeserver) shouldLearnState(ctx context.Context, roomId string) (bool, *storage.StoredRoom, error) {
-	_, ok := h.stateLearnCache.Get(roomId)
-	if ok {
-		// we already requested a state learn update for this room, so don't ask for another one.
-		return false, nil, nil
-	}
-
 	room, err := h.storage.GetRoom(ctx, roomId)
 	if err != nil {
 		return false, nil, err

--- a/homeserver/learn_state.go
+++ b/homeserver/learn_state.go
@@ -2,27 +2,15 @@ package homeserver
 
 import (
 	"context"
-	"encoding/json"
 	"errors"
 	"fmt"
 	"log"
-	"strings"
 	"time"
 
 	"github.com/matrix-org/gomatrixserverlib"
 	"github.com/matrix-org/gomatrixserverlib/spec"
 	"github.com/matrix-org/policyserv/storage"
-	"github.com/matrix-org/policyserv/trust"
 )
-
-type displayNameOnly struct {
-	DisplayName string `json:"displayname,omitempty"`
-}
-
-type minimalPolicyRule struct {
-	Recommendation string `json:"recommendation,omitempty"`
-	Entity         string `json:"entity,omitempty"`
-}
 
 func (h *Homeserver) shouldLearnState(ctx context.Context, roomId string) (bool, *storage.StoredRoom, error) {
 	room, err := h.storage.GetRoom(ctx, roomId)
@@ -40,13 +28,19 @@ func (h *Homeserver) shouldLearnState(ctx context.Context, roomId string) (bool,
 	return true, room, nil
 }
 
-func (h *Homeserver) LearnStateIfExpired(ctx context.Context, roomId string, atEventId string, via string) error {
-	shouldLearn, room, err := h.shouldLearnState(ctx, roomId)
+func (h *Homeserver) LearnState(ctx context.Context, roomId string, atEventId string, via string) error {
+	// Note: Previous implementation of this function used shouldLearnState() to only learn state if it was expired.
+	// In practice, we're reasonably confident that the fact that there's a queue of state to learn means that it's
+	// expired enough, so we always learn state regardless of how long it's been since the last update. Removing the
+	// expiration check also fixes an issue where the learn state task could be cleared for a room quietly, despite
+	// never actually learning state due to the task firing before the expiration time.
+
+	room, err := h.storage.GetRoom(ctx, roomId)
 	if err != nil {
 		return err
 	}
-	if !shouldLearn {
-		return nil
+	if room == nil {
+		return fmt.Errorf("room %s not found", roomId)
 	}
 
 	log.Printf("Fetching state for %s at %s from %s", roomId, atEventId, via)
@@ -57,84 +51,9 @@ func (h *Homeserver) LearnStateIfExpired(ctx context.Context, roomId string, atE
 	}
 	pdus := res.GetStateEvents().UntrustedEvents(gomatrixserverlib.RoomVersion(room.RoomVersion))
 
-	// Scan all events for the types we're looking for
-	userDisplayNames := make(map[string]string)
-	entityBans := make(map[string]string)
-	for _, pdu := range pdus {
-		// Find display names
-		if pdu.StateKeyEquals(string(pdu.SenderID())) && pdu.Type() == spec.MRoomMember {
-			membership, err := pdu.Membership()
-			if err != nil {
-				return errors.Join(fmt.Errorf("error parsing membership for %s / %s / %s", pdu.SenderID(), pdu.EventID(), pdu.RoomID()), err)
-			}
-			if membership == spec.Join {
-				content := displayNameOnly{}
-				err = json.Unmarshal(pdu.Content(), &content)
-				if err != nil {
-					return errors.Join(fmt.Errorf("error parsing displayname for %s / %s / %s", pdu.SenderID(), pdu.EventID(), pdu.RoomID()), err)
-				}
-				trimmed := strings.TrimSpace(content.DisplayName)
-				if len(trimmed) > 0 {
-					userDisplayNames[string(pdu.SenderID())] = content.DisplayName
-				}
-			}
-		}
-
-		// Find policy rules
-		if pdu.StateKey() != nil && len(*(pdu.StateKey())) > 0 && (pdu.Type() == "m.policy.rule.user" || pdu.Type() == "m.policy.rule.server") {
-			content := minimalPolicyRule{}
-			err = json.Unmarshal(pdu.Content(), &content)
-			if err != nil {
-				return errors.Join(fmt.Errorf("error parsing recommendation for %s / %s / %s", pdu.Type(), pdu.EventID(), pdu.RoomID()), err)
-			}
-			if content.Recommendation == "m.ban" && len(content.Entity) > 0 {
-				entityBans[content.Entity] = pdu.Type()
-			}
-		}
-
-		// Import all create events for sources
-		if pdu.Type() == "m.room.create" && pdu.StateKey() != nil && *(pdu.StateKey()) == "" {
-			log.Printf("Importing create event (%s) for %s", pdu.EventID(), roomId)
-			source, err := trust.NewCreatorSource(h.storage)
-			if err != nil {
-				log.Printf("Non-fatal error creating creator source: %v", err)
-			} else {
-				err = source.ImportData(ctx, roomId, pdu)
-				if err != nil {
-					log.Printf("Non-fatal error importing creator data: %v", err)
-				}
-			}
-		}
-
-		// Import all power level events for sources
-		if pdu.Type() == "m.room.power_levels" && pdu.StateKey() != nil && *(pdu.StateKey()) == "" {
-			log.Printf("Importing power levels event (%s) for %s", pdu.EventID(), roomId)
-			source, err := trust.NewPowerLevelsSource(h.storage)
-			if err != nil {
-				log.Printf("Non-fatal error creating power levels source: %v", err)
-			} else {
-				err = source.ImportData(ctx, roomId, pdu)
-				if err != nil {
-					log.Printf("Non-fatal error importing power levels data: %v", err)
-				}
-			}
-		}
-	}
-
-	// Process the displaynames
-	userIds := make([]string, 0)
-	displayNames := make([]string, 0)
-	for k, v := range userDisplayNames {
-		userIds = append(userIds, k)
-		displayNames = append(displayNames, v)
-	}
-	err = h.storage.SetUserIdsAndDisplayNamesByRoomId(ctx, roomId, userIds, displayNames)
+	err = h.stateLearner.LearnFrom(ctx, room, pdus)
 	if err != nil {
-		return errors.Join(fmt.Errorf("error storing displaynames for %s / %s", roomId, atEventId), err)
-	}
-	err = h.storage.SetListBanRules(ctx, roomId, entityBans)
-	if err != nil {
-		return errors.Join(fmt.Errorf("error storing list ban rules for %s / %s", roomId, atEventId), err)
+		return err
 	}
 
 	// Bump the cache timestamp, fetching a fresh `room` in case something changed while we've been processing the state

--- a/homeserver/learn_state_test.go
+++ b/homeserver/learn_state_test.go
@@ -1,0 +1,178 @@
+package homeserver
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"testing"
+	"testing/synctest"
+	"time"
+
+	"github.com/matrix-org/gomatrixserverlib"
+	"github.com/matrix-org/policyserv/internal"
+	"github.com/matrix-org/policyserv/storage"
+	"github.com/matrix-org/policyserv/test"
+	"github.com/stretchr/testify/assert"
+	"github.com/tidwall/sjson"
+)
+
+func TestShouldLearnState(t *testing.T) {
+	t.Parallel()
+
+	// We use synctest to manipulate time itself - see https://go.dev/blog/testing-time#time
+	synctest.Test(t, func(t *testing.T) {
+		// Dev note: We'd ideally use NewMockServerForTest here, but it ends up creating a bunch of stuff we
+		// don't need, like worker pools for filtering events. These other dependencies spin up a lot of
+		// goroutines which we can't easily shut down, which prevents synctest from passing. So, we create
+		// our own minimal homeserver instance with exactly what we need.
+		hs := &Homeserver{
+			storage:           test.NewMemoryStorage(t),
+			cacheRoomStateFor: 1 * time.Minute,
+		}
+
+		// Advance time by a little bit so we can do subtraction without overflow issues
+		time.Sleep(1 * time.Hour)
+
+		testCases := []struct {
+			lastCachedTimestamp int64
+			expectedShouldLearn bool
+		}{
+			{
+				// The room's last cached state was older than the CacheRoomStateFor time - shouldLearnState should be true
+				lastCachedTimestamp: time.Now().Add(-2 * time.Minute).UnixMilli(),
+				expectedShouldLearn: true,
+			},
+			{
+				// The room's last cached state is in the future (indicating it hasn't been expired) - shouldLearnState should be false
+				lastCachedTimestamp: time.Now().Add(2 * time.Minute).UnixMilli(),
+				expectedShouldLearn: false,
+			},
+			{
+				// When the room's last cached timestamp is exactly equal to CacheRoomStateFor's duration, we should learn state
+				lastCachedTimestamp: time.Now().Add(-1 * time.Minute).UnixMilli(),
+				expectedShouldLearn: true,
+			},
+			{
+				// When the cache is even 1ms too new, we should not learn state
+				lastCachedTimestamp: time.Now().Add(-1*time.Minute).UnixMilli() + 1,
+				expectedShouldLearn: false,
+			},
+		}
+
+		for i, tc := range testCases {
+			t.Logf("Test case %d: lastCachedTimestamp=%d, expectedShouldLearn=%t", i, tc.lastCachedTimestamp, tc.expectedShouldLearn)
+
+			// Insert the room to test it
+			room := &storage.StoredRoom{
+				RoomId:                         fmt.Sprintf("!%s:example.org", storage.NextId()),
+				LastCachedStateTimestampMillis: tc.lastCachedTimestamp,
+				RoomVersion:                    "10",
+			}
+			err := hs.storage.UpsertRoom(context.Background(), room)
+			assert.NoError(t, err)
+
+			shouldLearn, room2, err := hs.shouldLearnState(context.Background(), room.RoomId)
+			assert.NoError(t, err)
+			assert.Equal(t, tc.expectedShouldLearn, shouldLearn)
+			assert.Equal(t, room.RoomId, room2.RoomId)
+		}
+
+		synctest.Wait() // wait for goroutines to finish
+	})
+}
+
+func TestLearnState(t *testing.T) {
+	t.Parallel()
+
+	hs := NewMockServerForTest(t, test.NewMemoryStorage(t), func(c *Config) {
+		c.SkipVerify = true // our httptest server will have an unknown authority
+	})
+
+	// We should get an error on unknown room IDs
+	assert.EqualError(t, hs.LearnState(context.Background(), "!unknown:example.org", "$event", "example.org"), "room !unknown:example.org not found")
+
+	// Insert a room we'll use to test
+	room := &storage.StoredRoom{
+		RoomId:      "!test:example.org",
+		RoomVersion: "10",
+		// We set the last cached timestamp to be far in the future to ensure we *never* rely on this while learning
+		// state. When we ask to learn state, we want to always do that even if we recently learned state.
+		LastCachedStateTimestampMillis: time.Now().Add(500 * time.Hour).UnixMilli(),
+	}
+	err := hs.storage.UpsertRoom(context.Background(), room)
+	assert.NoError(t, err)
+
+	// Set up a server to learn state from
+	expectedAtEventId := "$at_this_event"
+	handlerCalled := false
+	handler := func(w http.ResponseWriter, r *http.Request) {
+		handlerCalled = true
+		assert.Equal(t, "/_matrix/federation/v1/state/"+room.RoomId, r.URL.Path)
+		assert.Equal(t, fmt.Sprintf("event_id=%s", url.QueryEscape(expectedAtEventId)), r.URL.RawQuery)
+
+		createEvent := MakeSignedPDUForTest(t, hs, &test.BaseClientEvent{
+			RoomId:   room.RoomId,
+			Type:     "m.room.create",
+			StateKey: internal.Pointer(""),
+			Sender:   "@alice:example.org",
+			Content: map[string]any{
+				"room_version": room.RoomVersion,
+			},
+		})
+
+		// Both the auth_chain and pdus are equivalent in this test, so populate both with the create event
+		resp, err := sjson.SetRawBytes([]byte(`{"auth_chain": [], "pdus": []}`), "auth_chain.0", createEvent.JSON())
+		assert.NoError(t, err)
+		resp, err = sjson.SetRawBytes(resp, "pdus.0", createEvent.JSON())
+		assert.NoError(t, err)
+
+		// Respond accordingly
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write(resp)
+	}
+	localhost := httptest.NewTLSServer(http.HandlerFunc(handler))
+	defer localhost.Close()
+	parsed, err := url.Parse(localhost.URL)
+	assert.NoError(t, err) // "should never happen"
+	localhostPort := parsed.Port()
+
+	// Override the state learner so we can detect that it was called properly
+	hs.stateLearner = &expectCreateEventLearner{
+		t:                 t,
+		inRoomId:          room.RoomId,
+		canLearnCallCount: 0,
+		doLearnCallCount:  0,
+	}
+
+	// Finally, we can make the state learning call
+	err = hs.LearnState(context.Background(), room.RoomId, expectedAtEventId, fmt.Sprintf("127.0.0.1:%s", localhostPort))
+	assert.NoError(t, err)
+	assert.True(t, handlerCalled)
+	assert.Equal(t, 0, hs.stateLearner.(*expectCreateEventLearner).canLearnCallCount) // not called in this path
+	assert.Equal(t, 1, hs.stateLearner.(*expectCreateEventLearner).doLearnCallCount)
+}
+
+type expectCreateEventLearner struct {
+	t                 *testing.T
+	canLearnCallCount int
+	doLearnCallCount  int
+	inRoomId          string
+}
+
+func (e *expectCreateEventLearner) CanLearn(ctx context.Context, room *storage.StoredRoom, event gomatrixserverlib.PDU) (bool, error) {
+	e.canLearnCallCount++
+	assert.NotNil(e.t, ctx, "context is required")
+	return event.Type() == "m.room.create" && room.RoomId == e.inRoomId, nil
+}
+
+func (e *expectCreateEventLearner) LearnFrom(ctx context.Context, room *storage.StoredRoom, roomState []gomatrixserverlib.PDU) error {
+	e.doLearnCallCount++
+	assert.NotNil(e.t, ctx, "context is required")
+	assert.Equal(e.t, e.inRoomId, room.RoomId)
+	assert.Equal(e.t, room.RoomId, roomState[0].RoomID().String())
+	assert.Equal(e.t, 1, len(roomState))
+	assert.Equal(e.t, "m.room.create", roomState[0].Type())
+	return nil
+}

--- a/homeserver/learning/learner_policy_rules.go
+++ b/homeserver/learning/learner_policy_rules.go
@@ -1,0 +1,65 @@
+package learning
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+
+	"github.com/matrix-org/gomatrixserverlib"
+	"github.com/matrix-org/policyserv/storage"
+)
+
+type PolicyRulesLearner struct {
+	storage storage.PersistentStorage
+}
+
+type minimalPolicyRule struct {
+	Recommendation string `json:"recommendation,omitempty"`
+	Entity         string `json:"entity,omitempty"`
+}
+
+func (p *PolicyRulesLearner) CanLearn(ctx context.Context, room *storage.StoredRoom, event gomatrixserverlib.PDU) (bool, error) {
+	if event.Type() != "m.policy.rule.user" && event.Type() != "m.policy.rule.room" {
+		return false, nil // wrong event type
+	}
+	if event.StateKey() == nil {
+		return false, nil // not a state event
+	}
+	content := minimalPolicyRule{}
+	err := json.Unmarshal(event.Content(), &content)
+	if err != nil {
+		return false, err
+	}
+	if content.Recommendation != "m.ban" {
+		return false, nil // not a ban rule
+	}
+	if len(content.Entity) == 0 {
+		return false, nil // no entity specified
+	}
+	return true, nil
+}
+
+func (p *PolicyRulesLearner) LearnFrom(ctx context.Context, room *storage.StoredRoom, roomState []gomatrixserverlib.PDU) error {
+	entityBans := make(map[string]string)
+	for _, pdu := range roomState {
+		ok, err := p.CanLearn(ctx, room, pdu)
+		if err != nil {
+			return err
+		}
+		if !ok {
+			continue
+		}
+		content := minimalPolicyRule{}
+		err = json.Unmarshal(pdu.Content(), &content)
+		if err != nil {
+			return errors.Join(fmt.Errorf("error parsing recommendation for %s / %s / %s", pdu.Type(), pdu.EventID(), pdu.RoomID()), err)
+		}
+		entityBans[content.Entity] = pdu.Type()
+	}
+	err := p.storage.SetListBanRules(ctx, room.RoomId, entityBans)
+	if err != nil {
+		return errors.Join(fmt.Errorf("error storing list ban rules for %s", room.RoomId), err)
+	}
+	return nil
+}

--- a/homeserver/learning/learner_room_members.go
+++ b/homeserver/learning/learner_room_members.go
@@ -1,0 +1,79 @@
+package learning
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"strings"
+
+	"github.com/matrix-org/gomatrixserverlib"
+	"github.com/matrix-org/gomatrixserverlib/spec"
+	"github.com/matrix-org/policyserv/storage"
+)
+
+type RoomMembersLearner struct {
+	storage storage.PersistentStorage
+}
+
+func (r *RoomMembersLearner) CanLearn(ctx context.Context, room *storage.StoredRoom, event gomatrixserverlib.PDU) (bool, error) {
+	if event.Type() != "m.room.member" {
+		return false, nil // not a member event
+	}
+	if event.StateKey() == nil {
+		return false, nil // not a state event
+	}
+	if !event.StateKeyEquals(string(event.SenderID())) {
+		return false, nil // probably not a join event
+	}
+	membership, err := event.Membership()
+	if err != nil {
+		return false, err // "should never happen"
+	}
+	if membership != spec.Join {
+		return false, nil // not a join event
+	}
+	return true, nil
+}
+
+type displayNameOnly struct {
+	DisplayName string `json:"displayname,omitempty"`
+}
+
+func (r *RoomMembersLearner) LearnFrom(ctx context.Context, room *storage.StoredRoom, roomState []gomatrixserverlib.PDU) error {
+	userDisplayNames := make(map[string]string)
+	for _, pdu := range roomState {
+		ok, err := r.CanLearn(ctx, room, pdu)
+		if err != nil {
+			return err
+		}
+		if !ok {
+			continue // not an event we care about
+		}
+
+		// Pull out the display name for mentions detection
+		content := displayNameOnly{}
+		err = json.Unmarshal(pdu.Content(), &content)
+		if err != nil {
+			return errors.Join(fmt.Errorf("error parsing displayname for %s / %s / %s", pdu.SenderID(), pdu.EventID(), pdu.RoomID()), err)
+		}
+		trimmed := strings.TrimSpace(content.DisplayName)
+		if len(trimmed) > 0 {
+			userDisplayNames[string(pdu.SenderID())] = content.DisplayName
+		}
+	}
+
+	// Process the display names and user IDs which are joined in the room
+	userIds := make([]string, 0)
+	displayNames := make([]string, 0)
+	for k, v := range userDisplayNames {
+		userIds = append(userIds, k)
+		displayNames = append(displayNames, v)
+	}
+	err := r.storage.SetUserIdsAndDisplayNamesByRoomId(ctx, room.RoomId, userIds, displayNames)
+	if err != nil {
+		return errors.Join(fmt.Errorf("error storing displaynames for %s", room.RoomId), err)
+	}
+
+	return nil
+}

--- a/homeserver/learning/learning.go
+++ b/homeserver/learning/learning.go
@@ -1,0 +1,65 @@
+package learning
+
+import (
+	"context"
+	"errors"
+	"log"
+
+	"github.com/matrix-org/gomatrixserverlib"
+	"github.com/matrix-org/policyserv/storage"
+	"github.com/matrix-org/policyserv/trust"
+)
+
+// RoomStateLearner is an EventStateLearner which calls into other EventStateLearner instances
+type RoomStateLearner struct {
+	storage  storage.PersistentStorage
+	learners []EventStateLearner
+}
+
+func NewRoomStateLearner(storage storage.PersistentStorage) (EventStateLearner, error) {
+	// XXX: It's a little bad that we're hardcoding learners this way. Ideally we'd use a registry.
+	mustConstruct := func(learner EventStateLearner, err error) EventStateLearner {
+		if err != nil {
+			log.Fatal("failed to construct learner", err)
+		}
+		return learner
+	}
+	learners := []EventStateLearner{
+		&RoomMembersLearner{storage: storage},
+		&PolicyRulesLearner{storage: storage},
+		mustConstruct(trust.NewPowerLevelsSource(storage)),
+		mustConstruct(trust.NewCreatorSource(storage)),
+	}
+
+	return &RoomStateLearner{
+		storage:  storage,
+		learners: learners,
+	}, nil
+}
+
+func (l *RoomStateLearner) CanLearn(ctx context.Context, room *storage.StoredRoom, event gomatrixserverlib.PDU) (bool, error) {
+	for _, learner := range l.learners {
+		canLearn, err := learner.CanLearn(ctx, room, event)
+		if err != nil {
+			return false, err
+		}
+		if canLearn {
+			return true, nil
+		}
+	}
+	return false, nil
+}
+
+func (l *RoomStateLearner) LearnFrom(ctx context.Context, room *storage.StoredRoom, roomState []gomatrixserverlib.PDU) error {
+	errs := make([]error, 0)
+	for _, learner := range l.learners {
+		err := learner.LearnFrom(ctx, room, roomState)
+		if err != nil {
+			errs = append(errs, err)
+		}
+	}
+	if len(errs) > 0 {
+		return errors.Join(errs...)
+	}
+	return nil
+}

--- a/homeserver/learning/types.go
+++ b/homeserver/learning/types.go
@@ -1,0 +1,21 @@
+package learning
+
+import (
+	"context"
+
+	"github.com/matrix-org/gomatrixserverlib"
+	"github.com/matrix-org/policyserv/storage"
+)
+
+// EventStateLearner is something which is capable of "learning" specific parts of room state. Usually these
+// will convert the state events received into a more usable format for later use.
+type EventStateLearner interface {
+	// CanLearn returns true if this can learn anything from the given event. Usually this is a type check.
+	// Note that the given event might not be a state event.
+	CanLearn(ctx context.Context, room *storage.StoredRoom, event gomatrixserverlib.PDU) (bool, error)
+
+	// LearnFrom processes the entire room state for a given room and learns whatever it can from it. The room
+	// state is not filtered by CanLearn - the implementation can do so if needed. The room state will always
+	// contain state events, and all events will be for the same room.
+	LearnFrom(ctx context.Context, room *storage.StoredRoom, roomState []gomatrixserverlib.PDU) error
+}

--- a/homeserver/run_filters.go
+++ b/homeserver/run_filters.go
@@ -6,7 +6,6 @@ import (
 	"log"
 	"time"
 
-	cache "github.com/Code-Hex/go-generics-cache"
 	"github.com/matrix-org/gomatrixserverlib"
 	"github.com/matrix-org/gomatrixserverlib/spec"
 	"github.com/matrix-org/policyserv/queue"
@@ -112,10 +111,6 @@ func (h *Homeserver) RunFilters(ctx context.Context, event gomatrixserverlib.PDU
 			if err != nil {
 				log.Printf("Error queueing state learning of %s at %s: %s", event.RoomID().String(), event.EventID(), err)
 			}
-
-			// Cache the fact that we've asked for a state learning update for this room (so we don't keep asking for one).
-			// We cache it for longer than the "after timestamp" because it might take a while for the state learning to happen.
-			h.stateLearnCache.Set(event.RoomID().String(), true, cache.WithExpiration(5*time.Minute))
 		}(h, event)
 	}(event, resultCh, waitCh)
 

--- a/tasks/state_cache.go
+++ b/tasks/state_cache.go
@@ -29,7 +29,7 @@ func CacheLearnedRoomState(homeserver *homeserver.Homeserver, db storage.Persist
 	}
 
 	log.Printf("Learning state: %#v", val)
-	err = homeserver.LearnStateIfExpired(ctx, val.RoomId, val.AtEventId, val.ViaServer)
+	err = homeserver.LearnState(ctx, val.RoomId, val.AtEventId, val.ViaServer)
 	if err != nil {
 		log.Printf("Non-fatal error learning state in %s at %s via %s: %v", val.RoomId, val.AtEventId, val.ViaServer, err)
 		return

--- a/tasks/state_cache_test.go
+++ b/tasks/state_cache_test.go
@@ -1,0 +1,91 @@
+package tasks
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"testing"
+
+	"github.com/matrix-org/policyserv/homeserver"
+	"github.com/matrix-org/policyserv/internal"
+	"github.com/matrix-org/policyserv/storage"
+	"github.com/matrix-org/policyserv/test"
+	"github.com/matrix-org/policyserv/trust"
+	"github.com/stretchr/testify/assert"
+	"github.com/tidwall/sjson"
+)
+
+func TestCacheLearnedRoomStateTask(t *testing.T) {
+	t.Parallel()
+
+	db := test.NewMemoryStorage(t)
+	hs := homeserver.NewMockServerForTest(t, db, func(c *homeserver.Config) {
+		c.SkipVerify = true // out httptest server will have an unknown authority
+	})
+
+	// Prepare a room to test the state queue
+	room := &storage.StoredRoom{
+		RoomId:      "!test:example.org",
+		RoomVersion: "10",
+	}
+	err := db.UpsertRoom(context.Background(), room)
+	assert.NoError(t, err)
+
+	// Prepare a test server to "learn" state from
+	handlerCalled := false
+	handler := func(w http.ResponseWriter, r *http.Request) {
+		handlerCalled = true
+
+		// We use a power levels event so we can detect that at least one of the learners worked
+		powerLevelsEvent := homeserver.MakeSignedPDUForTest(t, hs, &test.BaseClientEvent{
+			RoomId:   room.RoomId,
+			Type:     "m.room.power_levels",
+			StateKey: internal.Pointer(""),
+			Sender:   "@alice:example.org",
+			Content: map[string]any{
+				"users": map[string]any{
+					"@alice:example.org": 100,
+				},
+				"state_default": 50,
+				"users_default": 0,
+			},
+		})
+
+		// Both the auth_chain and pdus are equivalent in this test, so populate both with the create event
+		resp, err := sjson.SetRawBytes([]byte(`{"auth_chain": [], "pdus": []}`), "auth_chain.0", powerLevelsEvent.JSON())
+		assert.NoError(t, err)
+		resp, err = sjson.SetRawBytes(resp, "pdus.0", powerLevelsEvent.JSON())
+		assert.NoError(t, err)
+
+		// Respond accordingly
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write(resp)
+	}
+	localhost := httptest.NewTLSServer(http.HandlerFunc(handler))
+	defer localhost.Close()
+	parsed, err := url.Parse(localhost.URL)
+	assert.NoError(t, err) // "should never happen"
+	localhostPort := parsed.Port()
+
+	// Queue the task to learn the room's state
+	err = db.PushStateLearnQueue(context.Background(), &storage.StateLearnQueueItem{
+		RoomId:               room.RoomId,
+		AtEventId:            "$at_this_event",
+		ViaServer:            fmt.Sprintf("127.0.0.1:%s", localhostPort),
+		AfterTimestampMillis: 0, // effectively "now"
+	})
+	assert.NoError(t, err)
+
+	// Now we can call the task to ensure that the room's state is "learned"
+	CacheLearnedRoomState(hs, db)
+
+	// Verify the state was learned
+	assert.Equal(t, true, handlerCalled)
+	plSource, err := trust.NewPowerLevelsSource(db)
+	assert.NoError(t, err)
+	ok, err := plSource.IsUserAboveDefault(context.Background(), room.RoomId, "@alice:example.org")
+	assert.NoError(t, err)
+	assert.True(t, ok)
+}

--- a/trust/source_creator.go
+++ b/trust/source_creator.go
@@ -8,8 +8,8 @@ import (
 	"log"
 	"slices"
 
-	"github.com/matrix-org/policyserv/storage"
 	"github.com/matrix-org/gomatrixserverlib"
+	"github.com/matrix-org/policyserv/storage"
 )
 
 // CreatorSource - trusts v12+ room creators as high power level users
@@ -94,4 +94,25 @@ func (s *CreatorSource) ImportData(ctx context.Context, roomId string, createEve
 	data.CreatorUserIds = append(data.CreatorUserIds, content.AdditionalCreators...)
 
 	return s.db.SetTrustData(ctx, creatorSourceName, roomId, data)
+}
+
+func (s *CreatorSource) CanLearn(ctx context.Context, room *storage.StoredRoom, event gomatrixserverlib.PDU) (bool, error) {
+	roomVersion, err := gomatrixserverlib.GetRoomVersion(gomatrixserverlib.RoomVersion(room.RoomVersion))
+	if err != nil {
+		return false, err
+	}
+	return roomVersion.PrivilegedCreators() && event.Type() == "m.room.create" && event.StateKeyEquals(""), nil
+}
+
+func (s *CreatorSource) LearnFrom(ctx context.Context, room *storage.StoredRoom, roomState []gomatrixserverlib.PDU) error {
+	for _, event := range roomState {
+		ok, err := s.CanLearn(ctx, room, event)
+		if err != nil {
+			return err
+		}
+		if ok {
+			return s.ImportData(ctx, room.RoomId, event)
+		}
+	}
+	return nil
 }

--- a/trust/source_power_levels.go
+++ b/trust/source_power_levels.go
@@ -5,8 +5,8 @@ import (
 	"database/sql"
 	"errors"
 
-	"github.com/matrix-org/policyserv/storage"
 	"github.com/matrix-org/gomatrixserverlib"
+	"github.com/matrix-org/policyserv/storage"
 )
 
 // PowerLevelsSource - uses the room's power levels to determine trust levels. Above-default power levels are trusted.
@@ -65,4 +65,21 @@ func (s *PowerLevelsSource) ImportData(ctx context.Context, roomId string, power
 	}
 
 	return s.db.SetTrustData(ctx, powerLevelsSourceName, roomId, data)
+}
+
+func (s *PowerLevelsSource) CanLearn(ctx context.Context, room *storage.StoredRoom, event gomatrixserverlib.PDU) (bool, error) {
+	return event.Type() == "m.room.power_levels" && event.StateKeyEquals(""), nil
+}
+
+func (s *PowerLevelsSource) LearnFrom(ctx context.Context, room *storage.StoredRoom, roomState []gomatrixserverlib.PDU) error {
+	for _, event := range roomState {
+		ok, err := s.CanLearn(ctx, room, event)
+		if err != nil {
+			return err
+		}
+		if ok {
+			return s.ImportData(ctx, room.RoomId, event)
+		}
+	}
+	return nil
 }


### PR DESCRIPTION
**Reviewable commit-by-commit (recommended)**.

Fixes https://github.com/matrix-org/policyserv/issues/142

This introduces a new structure for how state is learned while also fixing the bug in #142. Instead of using a giant loop and if/else ladder, the new structure assigns "learners" (which are semi-recursive) for specific aspects of the room state. It's technically less efficient to loop over the room state so many times, but these loops should also be relatively quick anyway (even at 90k+ state events in a room).

The actual bug is fixed by removing the secondary state learning cache. The previous code was queuing a state learn task for 2 minutes into the future, but caching that request for 5 minutes. Then, when the task ran, the cache was checked to see if it "should" learn the state. Because the cache still had 3 minutes left on it, it thought that state learning was unnecessary and ultimately did nothing (and still marked the task as complete). This removes the code which was re-checking if we "should" be learning state because we ultimately don't care (we always want to learn state if we're instructed to do so), and removes the cache entirely because the persistence layer has a cache already to avoid excessive calls to the database to push to the queue.

**Note**: The new structure introduces a `CanLearn` function. This function is unused at the moment, but will be used in a future PR which makes state learning more intelligent. 

This also adds tests to the state learning area, where feasible. We don't yet have a concept of integration tests, but we try to get as close as possible here by testing each component on its own.

### Pull Request Checklist

<!-- Please read https://github.com/matrix-org/policyserv/CONTRIBUTING.md before submitting your pull request -->

* [x] Pull request is based on the `main` branch.
* [x] Pull request title describes the changes in a way a user would understand. For example, "Fix keywords filter not applying" instead of "Read keywords slice in a loop".
* [x] Code style matches surrounding code.
* [x] Tests are added for new code (and existing code) if possible.
  * If not possible, please explain why in your PR description. 
* [x] The CI checks pass.
