### PR TITLE
Attempt to process all state learning requests when the interval fires

### DIFF
--- a/tasks/state_cache.go
+++ b/tasks/state_cache.go
@@ -15,32 +15,40 @@ func CacheLearnedRoomState(homeserver *homeserver.Homeserver, db storage.Persist
 	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Minute)
 	defer cancel()
 
+	for popAndProcessStateLearnQueue(ctx, homeserver, db) {
+		// keep looping until we get `false`, indicating the end of results (or an error we can't really recover from)
+	}
+
+	log.Println("Finished learn state task")
+}
+
+func popAndProcessStateLearnQueue(ctx context.Context, homeserver *homeserver.Homeserver, db storage.PersistentStorage) (hasMore bool) {
 	val, txn, err := db.PopStateLearnQueue(ctx)
 	if txn != nil {
 		defer txn.Rollback() // if something goes wrong, just roll back.
 	}
 	if err != nil {
 		log.Printf("Non-fatal error popping state learn queue: %v", err)
-		return
+		return false
 	}
 	if val == nil {
 		log.Println("No state to learn")
-		return // no work to do
+		return false // no work to do
 	}
 
 	log.Printf("Learning state: %#v", val)
 	err = homeserver.LearnState(ctx, val.RoomId, val.AtEventId, val.ViaServer)
 	if err != nil {
 		log.Printf("Non-fatal error learning state in %s at %s via %s: %v", val.RoomId, val.AtEventId, val.ViaServer, err)
-		return
+		return false
 	}
 	log.Printf("State learned: %#v", val)
 
 	err = txn.Commit()
 	if err != nil {
 		log.Printf("Non-fatal error committing transaction: %v", err)
-		return
+		return false
 	}
 
-	log.Println("Finished learn state task")
+	return true
 }

--- a/tasks/state_cache_test.go
+++ b/tasks/state_cache_test.go
@@ -89,3 +89,96 @@ func TestCacheLearnedRoomStateTask(t *testing.T) {
 	assert.NoError(t, err)
 	assert.True(t, ok)
 }
+
+func TestCacheLearnRoomStateTaskMultipleRooms(t *testing.T) {
+	// Effectively the same as TestCacheLearnedRoomStateTask, but with multiple rooms to ensure a single task call
+	// will drain the queue.
+	t.Parallel()
+
+	db := test.NewMemoryStorage(t)
+	hs := homeserver.NewMockServerForTest(t, db, func(c *homeserver.Config) {
+		c.SkipVerify = true // out httptest server will have an unknown authority
+	})
+
+	// Prepare two rooms to test draining the queue
+	room1 := &storage.StoredRoom{
+		RoomId:      "!test_1:example.org",
+		RoomVersion: "10",
+	}
+	err := db.UpsertRoom(context.Background(), room1)
+	assert.NoError(t, err)
+	room2 := &storage.StoredRoom{
+		RoomId:      "!test_2:example.org",
+		RoomVersion: "10",
+	}
+	err = db.UpsertRoom(context.Background(), room2)
+	assert.NoError(t, err)
+
+	// Prepare a test server to "learn" state from
+	handlerCallCount := 0
+	handler := func(w http.ResponseWriter, r *http.Request) {
+		handlerCallCount++
+
+		roomId := r.URL.Path[len("/_matrix/federation/v1/state/"):]
+
+		// We use a power levels event so we can detect that at least one of the learners worked
+		powerLevelsEvent := homeserver.MakeSignedPDUForTest(t, hs, &test.BaseClientEvent{
+			RoomId:   roomId,
+			Type:     "m.room.power_levels",
+			StateKey: internal.Pointer(""),
+			Sender:   "@alice:example.org",
+			Content: map[string]any{
+				"users": map[string]any{
+					"@alice:example.org": 100,
+				},
+				"state_default": 50,
+				"users_default": 0,
+			},
+		})
+
+		// Both the auth_chain and pdus are equivalent in this test, so populate both with the create event
+		resp, err := sjson.SetRawBytes([]byte(`{"auth_chain": [], "pdus": []}`), "auth_chain.0", powerLevelsEvent.JSON())
+		assert.NoError(t, err)
+		resp, err = sjson.SetRawBytes(resp, "pdus.0", powerLevelsEvent.JSON())
+		assert.NoError(t, err)
+
+		// Respond accordingly
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write(resp)
+	}
+	localhost := httptest.NewTLSServer(http.HandlerFunc(handler))
+	defer localhost.Close()
+	parsed, err := url.Parse(localhost.URL)
+	assert.NoError(t, err) // "should never happen"
+	localhostPort := parsed.Port()
+
+	// Queue the tasks to learn the rooms' state
+	err = db.PushStateLearnQueue(context.Background(), &storage.StateLearnQueueItem{
+		RoomId:               room1.RoomId,
+		AtEventId:            "$at_this_event",
+		ViaServer:            fmt.Sprintf("127.0.0.1:%s", localhostPort),
+		AfterTimestampMillis: 0, // effectively "now"
+	})
+	assert.NoError(t, err)
+	err = db.PushStateLearnQueue(context.Background(), &storage.StateLearnQueueItem{
+		RoomId:               room2.RoomId,
+		AtEventId:            "$at_this_other_event",
+		ViaServer:            fmt.Sprintf("127.0.0.1:%s", localhostPort),
+		AfterTimestampMillis: 0, // effectively "now"
+	})
+	assert.NoError(t, err)
+
+	// Now we can call the task to ensure that both rooms' state are "learned"
+	CacheLearnedRoomState(hs, db)
+
+	// Verify the state was learned
+	assert.Equal(t, 2, handlerCallCount)
+	plSource, err := trust.NewPowerLevelsSource(db)
+	assert.NoError(t, err)
+	ok, err := plSource.IsUserAboveDefault(context.Background(), room1.RoomId, "@alice:example.org")
+	assert.NoError(t, err)
+	assert.True(t, ok)
+	ok, err = plSource.IsUserAboveDefault(context.Background(), room2.RoomId, "@alice:example.org")
+	assert.NoError(t, err)
+	assert.True(t, ok)
+}

--- a/test/memory_storage.go
+++ b/test/memory_storage.go
@@ -385,11 +385,15 @@ func mustClone[T any](t *testing.T, val *T) *T {
 }
 
 type memoryStateLearnTransaction struct { // Implements storage.Transaction
-	storage *MemoryStorage
-	row     *storage.StateLearnQueueItem
+	storage   *MemoryStorage
+	row       *storage.StateLearnQueueItem
+	committed bool
 }
 
 func (t *memoryStateLearnTransaction) Commit() error {
+	if t.committed {
+		return nil
+	}
 	newQueue := make([]*storage.StateLearnQueueItem, 0)
 	for _, item := range t.storage.pendingLearnStateQueue {
 		if item != t.row {
@@ -397,10 +401,14 @@ func (t *memoryStateLearnTransaction) Commit() error {
 		}
 	}
 	t.storage.pendingLearnStateQueue = newQueue
+	t.committed = true
 	return nil
 }
 
 func (t *memoryStateLearnTransaction) Rollback() error {
+	if t.committed {
+		return nil
+	}
 	t.storage.learnStateQueue = append(t.storage.learnStateQueue, t.row)
 	return t.Commit() // we're cheating a bit to avoid code duplication
 }

--- a/test/memory_storage_test.go
+++ b/test/memory_storage_test.go
@@ -103,12 +103,20 @@ func TestMemoryStorageStateLearnQueue(t *testing.T) {
 	assert.Equal(t, item1, ret4)
 	assert.NotNil(t, txn4)
 
-	// Finally, commit txn2 and ensure that it's gone
+	// Commit txn2 and ensure that it's gone
 	assert.NoError(t, txn2.Commit())
 	ret5, txn5, err := s.PopStateLearnQueue(context.Background())
 	assert.NoError(t, err)
 	assert.Nil(t, ret5)
 	assert.Nil(t, txn5)
+
+	// Finally, rollback the previous transaction to ensure it doesn't "restore" the queue. This
+	// is to ensure that calling code can use `defer Rollback()` without unexpected consequences.
+	assert.NoError(t, txn2.Rollback())
+	ret6, txn6, err := s.PopStateLearnQueue(context.Background())
+	assert.NoError(t, err)
+	assert.Nil(t, ret6)
+	assert.Nil(t, txn6)
 }
 
 func TestMemoryStorageTrustData(t *testing.T) {


### PR DESCRIPTION
**Requires https://github.com/matrix-org/policyserv/pull/144** (the base for this PR)

Fixes https://github.com/matrix-org/policyserv/issues/141

Note: this also fixes a bug in how the memory storage transaction works. Due to a `defer Rollback()`, the queue was being "restored", which was causing the new loop to become infinite. This bug doesn't happen in postgresql.

### Pull Request Checklist

<!-- Please read https://github.com/matrix-org/policyserv/CONTRIBUTING.md before submitting your pull request -->

* [x] Pull request is based on the `main` branch.
* [x] Pull request title describes the changes in a way a user would understand. For example, "Fix keywords filter not applying" instead of "Read keywords slice in a loop".
* [x] Code style matches surrounding code.
* [x] Tests are added for new code (and existing code) if possible.
  * If not possible, please explain why in your PR description. 
* [x] The CI checks pass.
