### PR TITLE
Order state learning requests by oldest first, ensuring the oldest rooms are processed ahead of newer ones

### DIFF
--- a/storage/psql.go
+++ b/storage/psql.go
@@ -532,7 +532,7 @@ func (s *PostgresStorage) PopStateLearnQueue(ctx context.Context) (*StateLearnQu
 	// This is why we start a transaction that tries to delete the row - this places a lock on the row.
 	// Note: we do the select and delete as a single operation to avoid a situation where another process takes
 	// a lock out on the same row as us.
-	r := txn.QueryRowContext(ctx, "DELETE FROM state_learn_queue WHERE room_id IN (SELECT s.room_id FROM state_learn_queue AS s WHERE after_ts <= (EXTRACT(EPOCH FROM NOW()) * 1000) LIMIT 1 FOR UPDATE SKIP LOCKED) RETURNING room_id, at_event_id, via, after_ts;")
+	r := txn.QueryRowContext(ctx, "DELETE FROM state_learn_queue WHERE room_id IN (SELECT s.room_id FROM state_learn_queue AS s WHERE after_ts <= (EXTRACT(EPOCH FROM NOW()) * 1000) ORDER BY after_ts ASC LIMIT 1 FOR UPDATE SKIP LOCKED) RETURNING room_id, at_event_id, via, after_ts;")
 	val := &StateLearnQueueItem{}
 	if err = r.Scan(&val.RoomId, &val.AtEventId, &val.ViaServer, &val.AfterTimestampMillis); err != nil {
 		if errors.Is(err, sql.ErrNoRows) {


### PR DESCRIPTION
Tests not possible due to being in the postgresql code. When we have integration tests we can test this.

### Pull Request Checklist

<!-- Please read https://github.com/matrix-org/policyserv/CONTRIBUTING.md before submitting your pull request -->

* [x] Pull request is based on the `main` branch.
* [x] Pull request title describes the changes in a way a user would understand. For example, "Fix keywords filter not applying" instead of "Read keywords slice in a loop".
* [x] Code style matches surrounding code.
* [x] Tests are added for new code (and existing code) if possible.
  * If not possible, please explain why in your PR description. 
* [x] The CI checks pass.
