### PR TITLE
Have state learning happen when a processable event is received

### DIFF
--- a/homeserver/learn_state.go
+++ b/homeserver/learn_state.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/matrix-org/gomatrixserverlib"
 	"github.com/matrix-org/gomatrixserverlib/spec"
+	"github.com/matrix-org/policyserv/queue"
 	"github.com/matrix-org/policyserv/storage"
 )
 
@@ -71,4 +72,77 @@ func (h *Homeserver) LearnState(ctx context.Context, roomId string, atEventId st
 	}
 
 	return nil
+}
+
+// queueLearnStateIfNeeded will silently decide if room state should be learned based on the result of a filter request
+// and the associated event. If state should be learned, it will be queued for processing.
+func (h *Homeserver) queueLearnStateIfNeeded(ctx context.Context, basedOnResult *queue.PoolResult, fromEvent gomatrixserverlib.PDU) {
+	// Create a new context so we're not tied to our caller's timeout. We aren't doing network calls here, so we can have
+	// something relatively short (we want to fail quickly if the database fails, for example).
+	ctx, cancel := context.WithTimeout(context.Background(), 1*time.Minute)
+	defer cancel()
+
+	// Verify that the event we're about to learn state based on is non-spammy in nature
+	if basedOnResult.Err != nil {
+		return // we're not interested in this result
+	}
+	if basedOnResult.IsProbablySpam {
+		return // too spammy for us
+	}
+
+	// Verify the event was sent by a "trusted" origin so we can learn state from them directly
+	trusted := false
+	for _, origin := range h.trustedOrigins {
+		userId := fromEvent.SenderID().ToUserID()
+		if userId == nil {
+			log.Printf("Non-user sender '%s' in %s at %s", fromEvent.SenderID(), fromEvent.RoomID().String(), fromEvent.EventID())
+			break
+		}
+		if userId.Domain() == spec.ServerName(origin) {
+			trusted = true
+			break
+		}
+	}
+	if !trusted {
+		return
+	}
+
+	// One of two conditions need to pass here: either we need to have expired state that should be updated, or the event
+	// being processed is something we can learn from directly (meaning we can avoid waiting for another event to arrive
+	// and process the queue - we can just do it right away).
+	shouldLearn, room, err := h.shouldLearnState(ctx, fromEvent.RoomID().String())
+	if err != nil {
+		log.Printf("Error checking if room %s should be learned: %s", fromEvent.RoomID().String(), err)
+		return
+	}
+	if !shouldLearn {
+		// we might still be able to learn from the event itself though
+		canLearn, err := h.stateLearner.CanLearn(ctx, room, fromEvent)
+		if err != nil {
+			log.Printf("Error checking if event %s can be learned: %s", fromEvent.EventID(), err)
+			return
+		}
+		if !canLearn {
+			return
+		}
+		log.Printf("Event %s in %s can be learned from directly", fromEvent.EventID(), fromEvent.RoomID().String())
+	} else {
+		log.Printf("Room %s has expired state that should be updated", fromEvent.RoomID().String())
+	}
+
+	// Now we're ready to queue the state learning task
+	// We queue the state learning so exactly one process will deal with it, instead of *all* of them.
+	// This queue also prevents us from learning state if multiple events come in before we finish
+	// learning state (ie: 4 events from matrix.org, all activate this bit of code, leading to 4
+	// concurrent "learn state" operations).
+	log.Printf("Queueing state learning of %s at %s", fromEvent.RoomID().String(), fromEvent.EventID())
+	err = h.storage.PushStateLearnQueue(ctx, &storage.StateLearnQueueItem{
+		RoomId:               fromEvent.RoomID().String(),
+		AtEventId:            fromEvent.EventID(),
+		ViaServer:            string(fromEvent.SenderID().ToUserID().Domain()),
+		AfterTimestampMillis: time.Now().Add(2 * time.Minute).UnixMilli(), // give the remote server a bit of time to process the event itself
+	})
+	if err != nil {
+		log.Printf("Error queueing state learning of %s at %s: %s", fromEvent.RoomID().String(), fromEvent.EventID(), err)
+	}
 }

--- a/homeserver/learn_state_test.go
+++ b/homeserver/learn_state_test.go
@@ -2,6 +2,7 @@ package homeserver
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"net/http"
 	"net/http/httptest"
@@ -12,6 +13,7 @@ import (
 
 	"github.com/matrix-org/gomatrixserverlib"
 	"github.com/matrix-org/policyserv/internal"
+	"github.com/matrix-org/policyserv/queue"
 	"github.com/matrix-org/policyserv/storage"
 	"github.com/matrix-org/policyserv/test"
 	"github.com/stretchr/testify/assert"
@@ -152,6 +154,131 @@ func TestLearnState(t *testing.T) {
 	assert.True(t, handlerCalled)
 	assert.Equal(t, 0, hs.stateLearner.(*expectCreateEventLearner).canLearnCallCount) // not called in this path
 	assert.Equal(t, 1, hs.stateLearner.(*expectCreateEventLearner).doLearnCallCount)
+}
+
+func TestQueueLearnStateIfNeeded(t *testing.T) {
+	t.Parallel()
+
+	// Create a server and event to test with. We also override the state learner so we can detect that
+	// it was called properly.
+	hs := NewMockServerForTest(t, test.NewMemoryStorage(t), func(c *Config) {
+		c.TrustedOrigins = []string{"example.org"}
+		c.CacheRoomStateFor = 1 * time.Minute
+	})
+	event := MakeSignedPDUForTest(t, hs, &test.BaseClientEvent{
+		RoomId:   "!test:example.org",
+		Type:     "m.room.create",
+		StateKey: internal.Pointer(""),
+		Sender:   "@alice:example.org",
+		Content: map[string]any{
+			"room_version": "10",
+		},
+	})
+	hs.stateLearner = &expectCreateEventLearner{
+		t:                 t,
+		inRoomId:          event.RoomID().String(),
+		canLearnCallCount: 0,
+		doLearnCallCount:  0,
+	}
+
+	// Spammy or errored results should *not* lead to a queued state learn attempt
+	res := &queue.PoolResult{
+		Err:            errors.New("should fail"),
+		IsProbablySpam: true,
+	}
+	hs.queueLearnStateIfNeeded(context.Background(), res, event)
+	assert.Equal(t, 0, hs.stateLearner.(*expectCreateEventLearner).canLearnCallCount)
+	assert.Equal(t, 0, hs.stateLearner.(*expectCreateEventLearner).doLearnCallCount)
+	next, txn, err := hs.storage.PopStateLearnQueue(context.Background())
+	assert.NoError(t, err)
+	assert.Nil(t, next)
+	assert.Nil(t, txn)
+	res.Err = nil // now check just the spam flag
+	hs.queueLearnStateIfNeeded(context.Background(), res, event)
+	assert.Equal(t, 0, hs.stateLearner.(*expectCreateEventLearner).canLearnCallCount)
+	assert.Equal(t, 0, hs.stateLearner.(*expectCreateEventLearner).doLearnCallCount)
+	next, txn, err = hs.storage.PopStateLearnQueue(context.Background())
+	assert.NoError(t, err)
+	assert.Nil(t, next)
+	assert.Nil(t, txn)
+
+	// Events sent by untrusted origins should not be learned
+	untrustedEvent := MakeSignedPDUForTest(t, hs, &test.BaseClientEvent{
+		RoomId:   event.RoomID().String(),
+		Type:     "m.room.create",
+		StateKey: internal.Pointer(""),
+		Sender:   "@alice:untrusted.example.org",
+		Content: map[string]any{
+			"room_version": "10",
+		},
+	})
+	hs.queueLearnStateIfNeeded(context.Background(), res, untrustedEvent)
+	assert.Equal(t, 0, hs.stateLearner.(*expectCreateEventLearner).canLearnCallCount)
+	assert.Equal(t, 0, hs.stateLearner.(*expectCreateEventLearner).doLearnCallCount)
+	next, txn, err = hs.storage.PopStateLearnQueue(context.Background())
+	assert.NoError(t, err)
+	assert.Nil(t, next)
+	assert.Nil(t, txn)
+
+	// If shouldLearnState throws an error, the room's state should not be learned. We simulate this by not
+	// creating a known room for the event, so the function should fail.
+	res.IsProbablySpam = false // flag the event as not spam
+	hs.queueLearnStateIfNeeded(context.Background(), res, event)
+	assert.Equal(t, 0, hs.stateLearner.(*expectCreateEventLearner).canLearnCallCount)
+	assert.Equal(t, 0, hs.stateLearner.(*expectCreateEventLearner).doLearnCallCount)
+	next, txn, err = hs.storage.PopStateLearnQueue(context.Background())
+	assert.NoError(t, err)
+	assert.Nil(t, next)
+	assert.Nil(t, txn)
+
+	// Now create the room, but ensure that it's state is still considered fresh.
+	room := &storage.StoredRoom{
+		RoomId:                         event.RoomID().String(),
+		RoomVersion:                    "10",
+		LastCachedStateTimestampMillis: time.Now().Add(10 * time.Minute).UnixMilli(),
+	}
+	err = hs.storage.UpsertRoom(context.Background(), room)
+	assert.NoError(t, err)
+
+	// Isolate the shouldLearnState check by providing an event we can't learn state from
+	nonCreateEvent := MakeSignedPDUForTest(t, hs, &test.BaseClientEvent{
+		RoomId: event.RoomID().String(),
+		Type:   "m.room.message",
+		Sender: "@alice:example.org",
+		Content: map[string]any{
+			"body": "doesn't matter",
+		},
+	})
+	hs.queueLearnStateIfNeeded(context.Background(), res, nonCreateEvent)
+	assert.Equal(t, 1, hs.stateLearner.(*expectCreateEventLearner).canLearnCallCount) // called but returns false
+	assert.Equal(t, 0, hs.stateLearner.(*expectCreateEventLearner).doLearnCallCount)
+	next, txn, err = hs.storage.PopStateLearnQueue(context.Background())
+	assert.NoError(t, err)
+	assert.Nil(t, next)
+	assert.Nil(t, txn)
+
+	// Now supply an event that can be learned from, but still has "fresh" state as far as LastCachedStateTimestamp
+	// is concerned.
+	hs.queueLearnStateIfNeeded(context.Background(), res, event)
+	assert.Equal(t, 2, hs.stateLearner.(*expectCreateEventLearner).canLearnCallCount)
+	assert.Equal(t, 0, hs.stateLearner.(*expectCreateEventLearner).doLearnCallCount)
+	next, txn, err = hs.storage.PopStateLearnQueue(context.Background())
+	assert.NoError(t, err)
+	assert.NotNil(t, txn)
+	assert.Equal(t, event.RoomID().String(), next.RoomId)
+	assert.NoError(t, txn.Commit()) // drain the queue ahead of the next test
+
+	// *Now* we can test that shouldLearnState is used when the room's state is expired
+	room.LastCachedStateTimestampMillis = time.Now().Add(-10 * time.Minute).UnixMilli()
+	assert.NoError(t, hs.storage.UpsertRoom(context.Background(), room))
+	hs.queueLearnStateIfNeeded(context.Background(), res, event)
+	assert.Equal(t, 2, hs.stateLearner.(*expectCreateEventLearner).canLearnCallCount) // not called again
+	assert.Equal(t, 0, hs.stateLearner.(*expectCreateEventLearner).doLearnCallCount)
+	next, txn, err = hs.storage.PopStateLearnQueue(context.Background())
+	assert.NoError(t, err)
+	assert.NotNil(t, txn)
+	assert.Equal(t, event.RoomID().String(), next.RoomId)
+	assert.NoError(t, txn.Commit()) // drain the queue ahead of the next test
 }
 
 type expectCreateEventLearner struct {

--- a/homeserver/run_filters.go
+++ b/homeserver/run_filters.go
@@ -4,12 +4,9 @@ import (
 	"context"
 	"errors"
 	"log"
-	"time"
 
 	"github.com/matrix-org/gomatrixserverlib"
-	"github.com/matrix-org/gomatrixserverlib/spec"
 	"github.com/matrix-org/policyserv/queue"
-	"github.com/matrix-org/policyserv/storage"
 )
 
 func (h *Homeserver) RunFilters(ctx context.Context, event gomatrixserverlib.PDU, waitCh chan<- *queue.PoolResult) error {
@@ -56,62 +53,8 @@ func (h *Homeserver) RunFilters(ctx context.Context, event gomatrixserverlib.PDU
 			}(ctx, downstream, res, event)
 		}
 
-		// We'd like to "learn" room state, if we can. First some checks to make sure we're in a good position to do that.
-
-		if res.Err != nil {
-			return // we're not interested in this result
-		}
-		if res.IsProbablySpam {
-			return // too spammy for us
-		}
-		trusted := false
-		for _, origin := range h.trustedOrigins {
-			userId := event.SenderID().ToUserID()
-			if userId == nil {
-				log.Printf("Non-user sender '%s' in %s at %s", event.SenderID(), event.RoomID().String(), event.EventID())
-				break
-			}
-			if userId.Domain() == spec.ServerName(origin) {
-				trusted = true
-				break
-			}
-		}
-		if !trusted {
-			return // not something we're willing to wait for
-		}
-
-		// At this point, it's "safe" to learn room state from that event, after we wait a bit for the
-		// remote server to finish processing/sending the event. We do that waiting in the background
-		// to avoid blocking this request any further (and thus the remote server's ability to finish
-		// processing the event).
-		go func(h *Homeserver, event gomatrixserverlib.PDU) {
-			ctx, cancel := context.WithTimeout(context.Background(), 5*time.Minute)
-			defer cancel()
-
-			shouldLearn, _, err := h.shouldLearnState(ctx, event.RoomID().String())
-			if err != nil {
-				log.Printf("Non-fatal error checking if we should learn state for %s: %s", event.RoomID().String(), err)
-				return
-			}
-			if !shouldLearn {
-				return
-			}
-
-			// We queue the state learning so exactly one process will deal with it, instead of *all* of them.
-			// This queue also prevents us from learning state if multiple events come in before we finish
-			// learning state (ie: 4 events from matrix.org, all activate this bit of code, leading to 4
-			// concurrent "learn state" operations).
-			log.Printf("Queueing state learning of %s at %s", event.RoomID().String(), event.EventID())
-			err = h.storage.PushStateLearnQueue(ctx, &storage.StateLearnQueueItem{
-				RoomId:               event.RoomID().String(),
-				AtEventId:            event.EventID(),
-				ViaServer:            string(event.SenderID().ToUserID().Domain()),
-				AfterTimestampMillis: time.Now().Add(2 * time.Minute).UnixMilli(), // give the remote server a bit of time to process the event itself
-			})
-			if err != nil {
-				log.Printf("Error queueing state learning of %s at %s: %s", event.RoomID().String(), event.EventID(), err)
-			}
-		}(h, event)
+		// We'd like to "learn" room state, if we can, so do that. We do this async to avoid blocking the filter request.
+		go h.queueLearnStateIfNeeded(ctx, res, event)
 	}(event, resultCh, waitCh)
 
 	return h.pool.Submit(ctx, event, h, resultCh)

--- a/homeserver/run_filters_test.go
+++ b/homeserver/run_filters_test.go
@@ -1,0 +1,73 @@
+package homeserver
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/matrix-org/policyserv/config"
+	"github.com/matrix-org/policyserv/internal"
+	"github.com/matrix-org/policyserv/queue"
+	"github.com/matrix-org/policyserv/storage"
+	"github.com/matrix-org/policyserv/test"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestRunFiltersQueuesStateLearning(t *testing.T) {
+	t.Parallel()
+
+	// Set up a homeserver which activates the happy path of queueLearnStateIfNeeded
+	hs := NewMockServerForTest(t, test.NewMemoryStorage(t), func(c *Config) {
+		c.TrustedOrigins = []string{"example.org"}
+		c.CacheRoomStateFor = 1 * time.Minute
+	})
+	event := MakeSignedPDUForTest(t, hs, &test.BaseClientEvent{
+		RoomId:   "!test:example.org",
+		Type:     "m.room.create",
+		StateKey: internal.Pointer(""),
+		Sender:   "@alice:example.org",
+		Content: map[string]any{
+			"room_version": "10",
+		},
+	})
+	hs.stateLearner = &expectCreateEventLearner{
+		t:                 t,
+		inRoomId:          event.RoomID().String(),
+		canLearnCallCount: 0,
+		doLearnCallCount:  0,
+	}
+	room := &storage.StoredRoom{
+		RoomId:                         event.RoomID().String(),
+		RoomVersion:                    "10",
+		LastCachedStateTimestampMillis: time.Now().Add(-10 * time.Minute).UnixMilli(),
+		CommunityId:                    "default",
+	}
+	err := hs.storage.UpsertRoom(context.Background(), room)
+	assert.NoError(t, err)
+	err = hs.storage.UpsertCommunity(context.Background(), &storage.StoredCommunity{
+		CommunityId: "default",
+		Name:        "Default Testing Community",
+		Config: &config.CommunityConfig{
+			EventTypePrefilterAllowedStateEventTypes: internal.Pointer([]string{event.Type()}),
+			EventTypePrefilterAllowedEventTypes:      internal.Pointer([]string{event.Type()}),
+		},
+	})
+	assert.NoError(t, err)
+
+	// Now we can call the RunFilters code. Note that this might cause side effects because it
+	// does a real scan of the event. We're only looking for the particular (async) side effect
+	// of state learning happening, though.
+	waitCh := make(chan *queue.PoolResult)
+	defer close(waitCh)
+	err = hs.RunFilters(context.Background(), event, waitCh)
+	assert.NoError(t, err)
+	// wait for the event to finish processing
+	assert.NotNil(t, <-waitCh)
+	// wait for the state learning to settle
+	time.Sleep(250 * time.Millisecond)
+	next, txn, err := hs.storage.PopStateLearnQueue(context.Background())
+	assert.NoError(t, err)
+	assert.NotNil(t, txn)
+	assert.Equal(t, event.RoomID().String(), next.RoomId)
+	assert.NoError(t, txn.Commit()) // drain the queue ahead of the next test
+}


### PR DESCRIPTION
Also move the state learning queue to a better place to make the filter running code a bit cleaner.

### Pull Request Checklist

<!-- Please read https://github.com/matrix-org/policyserv/CONTRIBUTING.md before submitting your pull request -->

* [x] Pull request is based on the `main` branch.
* [x] Pull request title describes the changes in a way a user would understand. For example, "Fix keywords filter not applying" instead of "Read keywords slice in a loop".
* [x] Code style matches surrounding code.
* [x] Tests are added for new code (and existing code) if possible.
  * If not possible, please explain why in your PR description. 
* [x] The CI checks pass.
