### PR TITLE
Add an always-on filter to ideally deny improper adds/removes of PS user

### DIFF
--- a/community/manager.go
+++ b/community/manager.go
@@ -94,7 +94,7 @@ func (m *Manager) GetFilterSetForCommunityId(ctx context.Context, communityId st
 		return nil, nil
 	}
 
-	prefilters := make([]string, 0)
+	prefilters := []string{filter.ProtectLocalUserFilterName}
 	hellbanPrefilters := make([]string, 0) // these run after the prefilters, but before the other filters
 	filters := make([]string, 0)
 	postfilters := make([]string, 0)

--- a/filter/filter_protect_local_user.go
+++ b/filter/filter_protect_local_user.go
@@ -1,0 +1,51 @@
+package filter
+
+import (
+	"context"
+	"fmt"
+	"log"
+
+	"github.com/matrix-org/gomatrixserverlib/spec"
+	"github.com/matrix-org/policyserv/filter/classification"
+)
+
+// Developer note: this filter is force-enabled and cannot be disabled.
+
+const ProtectLocalUserFilterName = "ProtectLocalUserFilter"
+
+func init() {
+	mustRegister(ProtectLocalUserFilterName, &ProtectLocalUserFilter{})
+}
+
+type ProtectLocalUserFilter struct {
+}
+
+func (f *ProtectLocalUserFilter) MakeFor(set *Set) (Instanced, error) {
+	return &InstancedProtectLocalUserFilter{
+		set:         set,
+		localUserId: spec.NewUserIDOrPanic(fmt.Sprintf("@%s:%s", set.instanceConfig.JoinLocalpart, set.instanceConfig.HomeserverName), false),
+	}, nil
+}
+
+type InstancedProtectLocalUserFilter struct {
+	set         *Set
+	localUserId spec.UserID
+}
+
+func (p *InstancedProtectLocalUserFilter) Name() string {
+	return ProtectLocalUserFilterName
+}
+
+func (p *InstancedProtectLocalUserFilter) CheckEvent(ctx context.Context, input *EventInput) ([]classification.Classification, error) {
+	if input.Event.Type() == "m.room.member" {
+		// If the state key is for our user ID, but the sender is different, then someone is trying to invite, kick, or ban our user. We
+		// don't want them to do that because it can break things - we should be managing it ourselves. The state key and sender will be
+		// the same on joins and self-leaves.
+		// XXX: This also denies invites, but we don't support them yet anyway - https://github.com/matrix-org/policyserv/issues/91
+		if input.Event.StateKeyEquals(p.localUserId.String()) && input.Event.SenderID().ToUserID().String() != p.localUserId.String() {
+			log.Printf("[%s | %s] %s tried to add/remove policyserv user improperly", input.Event.EventID(), input.Event.RoomID(), input.Event.SenderID())
+			return []classification.Classification{classification.Spam}, nil
+		}
+	}
+	return nil, nil
+}

--- a/filter/filter_protect_local_user_test.go
+++ b/filter/filter_protect_local_user_test.go
@@ -1,0 +1,72 @@
+package filter
+
+import (
+	"context"
+	"testing"
+
+	"github.com/matrix-org/gomatrixserverlib"
+	"github.com/matrix-org/policyserv/config"
+	"github.com/matrix-org/policyserv/filter/classification"
+	"github.com/matrix-org/policyserv/internal"
+	"github.com/matrix-org/policyserv/test"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestProtectLocalUserFilter(t *testing.T) {
+	t.Parallel()
+
+	cnf := &SetConfig{
+		CommunityConfig: &config.CommunityConfig{},
+		InstanceConfig: &config.InstanceConfig{
+			HomeserverName: "example.org",
+			JoinLocalpart:  "alice",
+		},
+		Groups: []*SetGroupConfig{{
+			// The filter is force-enabled in the community manager, which we need to mimic here
+			EnabledNames:           []string{ProtectLocalUserFilterName},
+			MinimumSpamVectorValue: 0.0,
+			MaximumSpamVectorValue: 1.0,
+		}},
+	}
+	memStorage := test.NewMemoryStorage(t)
+	defer memStorage.Close()
+	ps := test.NewMemoryPubsub(t)
+	defer ps.Close()
+	set, err := NewSet(cnf, memStorage, ps, test.MustMakeAuditQueue(5), nil)
+	assert.NoError(t, err)
+	assert.NotNil(t, set)
+
+	spammyEvent1 := test.MustMakePDU(&test.BaseClientEvent{
+		EventId:  "$spam1",
+		RoomId:   "!foo:example.org",
+		Type:     "m.room.member",
+		Sender:   "@bob:example.org",
+		StateKey: internal.Pointer("@alice:example.org"),
+		Content: map[string]any{
+			"membership": "doesn't matter",
+		},
+	})
+	neutralEvent1 := test.MustMakePDU(&test.BaseClientEvent{
+		EventId:  "$neutral1",
+		RoomId:   "!foo:example.org",
+		Type:     "m.room.member",
+		Sender:   "@alice:example.org",
+		StateKey: internal.Pointer("@alice:example.org"),
+		Content: map[string]any{
+			"membership": "doesn't matter",
+		},
+	})
+
+	assertSpamVector := func(event gomatrixserverlib.PDU, isSpam bool) {
+		vecs, err := set.CheckEvent(context.Background(), event, nil)
+		assert.NoError(t, err)
+		if isSpam {
+			assert.Equal(t, 1.0, vecs.GetVector(classification.Spam))
+		} else {
+			// Because the filter doesn't flag things as "not spam", the seed value should survive
+			assert.Equal(t, 0.5, vecs.GetVector(classification.Spam))
+		}
+	}
+	assertSpamVector(spammyEvent1, true)
+	assertSpamVector(neutralEvent1, false)
+}


### PR DESCRIPTION
This might not work if the server sending the event ignored the policy server. This is meant as a best effort solution rather than a comprehensive fix to deter accidental cases from happening.

In practice, most communities setting up a policy server (and therefore have permission to remove/kick the policyserv user) will also have an updated, spec-compliant, homeserver. This should cause their efforts to kick/ban the policyserv user to be denied.

**Note**: This might not work on Synapse servers either. Fixing that is a WIP.

### Pull Request Checklist

<!-- Please read https://github.com/matrix-org/policyserv/CONTRIBUTING.md before submitting your pull request -->

* [x] Pull request is based on the `main` branch.
* [x] Pull request title describes the changes in a way a user would understand. For example, "Fix keywords filter not applying" instead of "Read keywords slice in a loop".
* [x] Code style matches surrounding code.
* [x] Tests are added for new code (and existing code) if possible.
  * If not possible, please explain why in your PR description. 
* [x] The CI checks pass.
