### PR TITLE
Add ability to serve harms on errors

### DIFF
--- a/api/errors.go
+++ b/api/errors.go
@@ -12,16 +12,36 @@ type errorResponder struct {
 	action string
 	w      http.ResponseWriter
 	r      *http.Request
+	harms  []string
+}
+
+func (e *errorResponder) addHarm(harm string) *errorResponder {
+	e.harms = append(e.harms, harm)
+	return e
 }
 
 func (e *errorResponder) text(httpCode int, errcode string, error string) {
 	defer metrics.RecordHttpResponse(e.r.Method, e.action, httpCode)
-	homeserver.MatrixHttpError(e.w, httpCode, errcode, error)
+	homeserver.MustServeError(e.w, &homeserver.ClientError{
+		HttpCode: httpCode,
+		Errcode:  errcode,
+		Message:  error,
+		AdditionalFields: map[string]any{
+			"org.matrix.msc4387.harms": e.harms,
+		},
+	})
 }
 
 func (e *errorResponder) err(httpCode int, errcode string, err error) {
 	log.Printf("%s error (%d/%s): %v", e.action, httpCode, errcode, err)
-	e.text(httpCode, errcode, "Error")
+	homeserver.MustServeError(e.w, &homeserver.ClientError{
+		HttpCode: httpCode,
+		Errcode:  errcode,
+		Message:  "Error",
+		AdditionalFields: map[string]any{
+			"org.matrix.msc4387.harms": e.harms,
+		},
+	})
 }
 
 func newErrorResponder(action string, w http.ResponseWriter, r *http.Request) *errorResponder {
@@ -29,5 +49,6 @@ func newErrorResponder(action string, w http.ResponseWriter, r *http.Request) *e
 		action: action,
 		w:      w,
 		r:      r,
+		harms:  make([]string, 0),
 	}
 }

--- a/api/http_server_api_check.go
+++ b/api/http_server_api_check.go
@@ -5,6 +5,7 @@ import (
 	"log"
 	"net/http"
 
+	"github.com/matrix-org/policyserv/filter/classification"
 	"github.com/matrix-org/policyserv/metrics"
 	"github.com/matrix-org/policyserv/queue"
 	"github.com/matrix-org/policyserv/storage"
@@ -42,7 +43,10 @@ func httpCheckTextCommunityApi(api *Api, community *storage.StoredCommunity, w h
 	}
 
 	if set.IsSpamResponse(r.Context(), vecs) {
-		// TODO: Also disclose MSC4387 harms, somehow
+		errs.addHarm("org.matrix.msc4387.spam")
+		if vecs.GetVector(classification.CSAM) > 0.5 {
+			errs.addHarm("org.matrix.msc4387.child_safety.csam")
+		}
 		errs.text(http.StatusBadRequest, "ORG.MATRIX.MSC4387_SAFETY", "Text is probably spammy")
 	} else {
 		err = respondJson("httpCheckTextCommunityApi", r, w, make(map[string]any))

--- a/api/http_server_api_check_test.go
+++ b/api/http_server_api_check_test.go
@@ -51,6 +51,7 @@ func TestHttpCheckTextCommunityApi(t *testing.T) {
 	httpCheckTextCommunityApi(api, serverCommunity, w, r)
 	assert.Equal(t, http.StatusBadRequest, w.Code)
 	test.AssertApiError(t, w, "ORG.MATRIX.MSC4387_SAFETY", "Text is probably spammy")
+	test.AssertApiErrorHarms(t, w, []string{"org.matrix.msc4387.spam"})
 
 	// Then test a non-match
 	w = httptest.NewRecorder()

--- a/homeserver/errors.go
+++ b/homeserver/errors.go
@@ -1,12 +1,41 @@
 package homeserver
 
 import (
-	"fmt"
+	"encoding/json"
+	"log"
 	"net/http"
 )
 
+type ClientError struct {
+	HttpCode         int
+	Errcode          string
+	Message          string
+	AdditionalFields map[string]any
+}
+
 func MatrixHttpError(w http.ResponseWriter, code int, errcode string, msg string) {
+	MustServeError(w, &ClientError{
+		HttpCode: code,
+		Errcode:  errcode,
+		Message:  msg,
+	})
+}
+
+func MustServeError(w http.ResponseWriter, clientErr *ClientError) {
 	w.Header().Set("Content-Type", "application/json")
-	w.WriteHeader(code)
-	_, _ = w.Write([]byte(fmt.Sprintf(`{"errcode": "%s", "error": "%s"}`, errcode, msg)))
+	w.WriteHeader(clientErr.HttpCode)
+
+	// To get `AdditionalFields` to show up at the top level of the JSON object, we populate the error
+	// details into it then marshal the result.
+	if clientErr.AdditionalFields == nil {
+		clientErr.AdditionalFields = make(map[string]any)
+	}
+	clientErr.AdditionalFields["errcode"] = clientErr.Errcode
+	clientErr.AdditionalFields["error"] = clientErr.Message
+	b, err := json.Marshal(clientErr.AdditionalFields)
+	if err != nil {
+		log.Fatal(err)
+		return
+	}
+	_, _ = w.Write(b)
 }

--- a/homeserver/errors_test.go
+++ b/homeserver/errors_test.go
@@ -1,0 +1,44 @@
+package homeserver
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestMatrixHttpError(t *testing.T) {
+	t.Parallel()
+
+	w := httptest.NewRecorder()
+	MatrixHttpError(w, http.StatusBadRequest, "M_FORBIDDEN", "Example error message")
+	assert.Equal(t, w.Code, http.StatusBadRequest)
+	assert.Equal(t, w.Body.String(), `{"errcode":"M_FORBIDDEN","error":"Example error message"}`)
+}
+
+func TestMustServeError(t *testing.T) {
+	t.Parallel()
+
+	w := httptest.NewRecorder()
+	MustServeError(w, &ClientError{
+		HttpCode: http.StatusBadRequest,
+		Errcode:  "M_FORBIDDEN",
+		Message:  "Example error message",
+		AdditionalFields: map[string]any{
+			"example_field": "example_value",
+		},
+	})
+	assert.Equal(t, w.Code, http.StatusBadRequest)
+	assert.Equal(t, w.Body.String(), `{"errcode":"M_FORBIDDEN","error":"Example error message","example_field":"example_value"}`)
+
+	// AdditionalFields should also be optional
+	w = httptest.NewRecorder()
+	MustServeError(w, &ClientError{
+		HttpCode: http.StatusBadRequest,
+		Errcode:  "M_FORBIDDEN",
+		Message:  "Example error message",
+	})
+	assert.Equal(t, w.Code, http.StatusBadRequest)
+	assert.Equal(t, w.Body.String(), `{"errcode":"M_FORBIDDEN","error":"Example error message"}`)
+}

--- a/test/api.go
+++ b/test/api.go
@@ -30,3 +30,10 @@ func AssertJsonBody(t *testing.T, w *httptest.ResponseRecorder, expected any) {
 	assert.NoError(t, err)
 	assert.JSONEq(t, string(expectedJson), w.Body.String())
 }
+
+func AssertApiErrorHarms(t *testing.T, w *httptest.ResponseRecorder, expectedHarms []string) {
+	jsonErr := make(map[string]any)
+	err := json.Unmarshal(w.Body.Bytes(), &jsonErr)
+	assert.NoError(t, err)
+	assert.Equal(t, expectedHarms, jsonErr["org.matrix.msc3026.harms"])
+}

--- a/test/api.go
+++ b/test/api.go
@@ -31,9 +31,13 @@ func AssertJsonBody(t *testing.T, w *httptest.ResponseRecorder, expected any) {
 	assert.JSONEq(t, string(expectedJson), w.Body.String())
 }
 
+type harmsOnly struct {
+	Harms []string `json:"org.matrix.msc4387.harms"`
+}
+
 func AssertApiErrorHarms(t *testing.T, w *httptest.ResponseRecorder, expectedHarms []string) {
-	jsonErr := make(map[string]any)
+	jsonErr := harmsOnly{}
 	err := json.Unmarshal(w.Body.Bytes(), &jsonErr)
 	assert.NoError(t, err)
-	assert.Equal(t, expectedHarms, jsonErr["org.matrix.msc3026.harms"])
+	assert.Equal(t, expectedHarms, jsonErr.Harms)
 }


### PR DESCRIPTION
This might get replaced with something better when we internally rewrite things to use harms instead of classifications. For now though, this is "fine".

### Pull Request Checklist

<!-- Please read https://github.com/matrix-org/policyserv/CONTRIBUTING.md before submitting your pull request -->

* [x] Pull request is based on the `main` branch.
* [x] Pull request title describes the changes in a way a user would understand. For example, "Fix keywords filter not applying" instead of "Read keywords slice in a loop".
* [x] Code style matches surrounding code.
* [x] Tests are added for new code (and existing code) if possible.
  * If not possible, please explain why in your PR description. 
* [x] The CI checks pass.
