### PR TITLE
Internal: Remove unused `GetStorage` function on Set

### DIFF
--- a/filter/set.go
+++ b/filter/set.go
@@ -74,11 +74,6 @@ func NewSet(config *SetConfig, storage storage.PersistentStorage, pubsub pubsub.
 	return set, nil
 }
 
-// GetStorage - Accessor to the underlying PersistentStorage
-func (s *Set) GetStorage() storage.PersistentStorage {
-	return s.storage
-}
-
 // CheckEvent - Checks an event over all of the set groups in order. If a set group errors, execution stops there.
 // Note: the mediaDownloader may be nil to prevent parsing and downloading of media. This should only be done in test environments.
 func (s *Set) CheckEvent(ctx context.Context, event gomatrixserverlib.PDU, mediaDownloader media.Downloader) (confidence.Vectors, error) {

--- a/filter/set_test.go
+++ b/filter/set_test.go
@@ -40,8 +40,6 @@ func TestNewSet(t *testing.T) {
 	assert.NoError(t, err)
 	assert.NotNil(t, set)
 
-	assert.Equal(t, set.GetStorage(), memStorage)
-
 	assert.Equal(t, len(cnf.Groups), len(set.groups))
 	assert.Equal(t, len(cnf.Groups[0].EnabledNames), len(set.groups[0].filters))
 


### PR DESCRIPTION
Noticed while refactoring other code in the area. Because filters are in the same package, we typically just grab the storage directly.

### Pull Request Checklist

<!-- Please read https://github.com/matrix-org/policyserv/CONTRIBUTING.md before submitting your pull request -->

* [x] Pull request is based on the `main` branch.
* [x] Pull request title describes the changes in a way a user would understand. For example, "Fix keywords filter not applying" instead of "Read keywords slice in a loop".
* [x] Code style matches surrounding code.
* [x] Tests are added for new code (and existing code) if possible.
  * If not possible, please explain why in your PR description. 
* [x] The CI checks pass.
