### PR TITLE
Internal: Introduce support for "conditions" on filters

### DIFF
--- a/filter/condition/README.md
+++ b/filter/condition/README.md
@@ -1,0 +1,38 @@
+# Conditions package - developer notes
+
+Usually in a Go program the function which creates a `struct` would be something like `NewMyStruct`, but this package
+does something a little different. To make the functions a bit more natural to read outside the package, the constructors
+fit a more natural language instead.
+
+For example:
+
+```go
+conditions.AllOf(
+    conditions.TimeOfDay(x),
+	conditions.AnyOf(
+		conditions.RoomId(x),
+		conditions.Not(
+			conditions.AnyIn(conditions.CommunityId, []{x, y, z})
+		),
+	),
+)
+```
+
+A normal Go program would look something like this:
+
+```go
+conditions.NewMatchAllCondition(
+    conditions.NewTimeOfDayCondition(x),
+	conditions.NewMatchAnyCondition(
+		conditions.NewRoomIdCondition(x),
+        conditions.NewInvertedCondition(
+            conditions.NewMatchAnyInSliceCondition(conditions.CommunityId, []{x, y, z})
+        ),
+	),
+)
+```
+
+... which isn't as nice as the first example.
+
+To make the constructors easier to find, files in this package should fit the format `condition_{snake_case_constructor}.go`.
+This means `AnyOf` becomes `condition_any_of.go`.

--- a/filter/condition/condition_all_of.go
+++ b/filter/condition/condition_all_of.go
@@ -1,0 +1,16 @@
+package condition
+
+import "context"
+
+// AllOf - ANDs all the conditions together, returning true if all the conditions return true. If a condition
+// doesn't match, this won't check the remaining conditions.
+func AllOf(conditions ...Condition) Condition {
+	return newSimpleCondition(func(ctx context.Context, communityId string, roomId string, senderUserId string) bool {
+		for _, condition := range conditions {
+			if !condition.Matches(ctx, communityId, roomId, senderUserId) {
+				return false
+			}
+		}
+		return true
+	})
+}

--- a/filter/condition/condition_all_of_test.go
+++ b/filter/condition/condition_all_of_test.go
@@ -1,0 +1,32 @@
+package condition
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestAllOf(t *testing.T) {
+	c := AllOf(
+		AlwaysTrue(t),
+		AlwaysFalse(t),
+		FuncCondition(t, func(communityId string, roomId string, senderUserId string) bool {
+			t.Error("should not have been called")
+			return false
+		}),
+	)
+	assert.False(t, c.Matches(context.Background(), "whatever", "whatever", "whatever"))
+
+	called := false
+	c = AllOf(
+		AlwaysTrue(t),
+		AlwaysTrue(t),
+		FuncCondition(t, func(communityId string, roomId string, senderUserId string) bool {
+			called = true
+			return true
+		}),
+	)
+	assert.True(t, c.Matches(context.Background(), "whatever", "whatever", "whatever"))
+	assert.True(t, called)
+}

--- a/filter/condition/condition_any_in.go
+++ b/filter/condition/condition_any_in.go
@@ -1,0 +1,10 @@
+package condition
+
+// AnyIn - A shortcut to create an AnyOf condition for a set of values, like room IDs.
+func AnyIn[T any](constructor func(val T) Condition, vals []T) Condition {
+	conditions := make([]Condition, len(vals))
+	for i, val := range vals {
+		conditions[i] = constructor(val)
+	}
+	return AnyOf(conditions...)
+}

--- a/filter/condition/condition_any_in_test.go
+++ b/filter/condition/condition_any_in_test.go
@@ -1,0 +1,36 @@
+package condition
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestAnyIn(t *testing.T) {
+	called := make([]bool, 3)
+
+	funcConditionProxy := func(fn TestConditionMatchesFn) Condition {
+		return FuncCondition(t, fn)
+	}
+
+	vals := []TestConditionMatchesFn{
+		func(communityId string, roomId string, senderUserId string) bool {
+			called[0] = true
+			return false
+		},
+		func(communityId string, roomId string, senderUserId string) bool {
+			called[1] = true
+			return false
+		},
+		func(communityId string, roomId string, senderUserId string) bool {
+			called[2] = true
+			return true
+		},
+	}
+	c := AnyIn(funcConditionProxy, vals)
+	assert.True(t, c.Matches(context.Background(), "whatever", "whatever", "whatever"))
+	assert.True(t, called[0])
+	assert.True(t, called[1])
+	assert.True(t, called[2])
+}

--- a/filter/condition/condition_any_of.go
+++ b/filter/condition/condition_any_of.go
@@ -1,0 +1,16 @@
+package condition
+
+import "context"
+
+// AnyOf - ORs each of the conditions, returning true when the first condition does. Does not check the
+// remaining conditions.
+func AnyOf(conditions ...Condition) Condition {
+	return newSimpleCondition(func(ctx context.Context, communityId string, roomId string, senderUserId string) bool {
+		for _, condition := range conditions {
+			if condition.Matches(ctx, communityId, roomId, senderUserId) {
+				return true
+			}
+		}
+		return false
+	})
+}

--- a/filter/condition/condition_any_of_test.go
+++ b/filter/condition/condition_any_of_test.go
@@ -1,0 +1,28 @@
+package condition
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestAnyOf(t *testing.T) {
+	c := AnyOf(
+		AlwaysFalse(t),
+		AlwaysFalse(t),
+		AlwaysTrue(t),
+	)
+	assert.True(t, c.Matches(context.Background(), "whatever", "whatever", "whatever"))
+
+	c = AnyOf(
+		AlwaysFalse(t),
+		AlwaysFalse(t),
+		AlwaysTrue(t),
+		FuncCondition(t, func(communityId string, roomId string, senderUserId string) bool {
+			t.Error("should not have been called")
+			return false
+		}),
+	)
+	assert.True(t, c.Matches(context.Background(), "whatever", "whatever", "whatever"))
+}

--- a/filter/condition/condition_not.go
+++ b/filter/condition/condition_not.go
@@ -1,0 +1,10 @@
+package condition
+
+import "context"
+
+// Not - Inverts the downstream condition's Matches call.
+func Not(condition Condition) Condition {
+	return newSimpleCondition(func(ctx context.Context, communityId string, roomId string, senderUserId string) bool {
+		return !condition.Matches(ctx, communityId, roomId, senderUserId)
+	})
+}

--- a/filter/condition/condition_not_test.go
+++ b/filter/condition/condition_not_test.go
@@ -1,0 +1,13 @@
+package condition
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestNot(t *testing.T) {
+	c := Not(AlwaysTrue(t))
+	assert.False(t, c.Matches(context.Background(), "whatever", "whatever", "whatever"))
+}

--- a/filter/condition/condition_room_id.go
+++ b/filter/condition/condition_room_id.go
@@ -1,0 +1,9 @@
+package condition
+
+import "context"
+
+func RoomId(onlyInRoomId string) Condition {
+	return newSimpleCondition(func(ctx context.Context, communityId string, roomId string, senderUserId string) bool {
+		return onlyInRoomId == roomId
+	})
+}

--- a/filter/condition/condition_room_id_test.go
+++ b/filter/condition/condition_room_id_test.go
@@ -1,0 +1,14 @@
+package condition
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestRoomId(t *testing.T) {
+	c := RoomId("!this one")
+	assert.True(t, c.Matches(context.Background(), "whatever", "!this one", "whatever"))
+	assert.False(t, c.Matches(context.Background(), "whatever", "not this one", "whatever"))
+}

--- a/filter/condition/types.go
+++ b/filter/condition/types.go
@@ -1,0 +1,31 @@
+package condition
+
+import "context"
+
+// Condition - Determines if a filter should be run based on the described condition.
+type Condition interface {
+	// Matches - Returns true if the filter should be run, false otherwise. Venue and sender information for the input
+	// is provided, but notably the event/text/content itself is excluded. Filters check contents, conditions check venues.
+	Matches(ctx context.Context, communityId string, roomId string, senderUserId string) bool
+}
+
+// Dev note: we could probably get away with Condition being a type alias for conditionFunc instead of being an interface
+// type, but then we lose the ability to have more complex conditions with long-lived dependencies. So, we use the
+// interface type early to avoid having to refactor later.
+//
+// It's also just clearer to see "condition.Matches(x)" than it is "condition(x)".
+
+type conditionFunc func(ctx context.Context, communityId string, roomId string, senderUserId string) bool
+
+// simpleCondition - Makes setting up conditions with few/no dependencies a bit easier.
+type simpleCondition struct {
+	fn conditionFunc
+}
+
+func newSimpleCondition(fn conditionFunc) Condition {
+	return &simpleCondition{fn: fn}
+}
+
+func (c *simpleCondition) Matches(ctx context.Context, communityId string, roomId string, senderUserId string) bool {
+	return c.fn(ctx, communityId, roomId, senderUserId)
+}

--- a/filter/condition/types_test.go
+++ b/filter/condition/types_test.go
@@ -1,0 +1,57 @@
+package condition
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+type TestConditionMatchesFn func(communityId string, roomId string, senderUserId string) bool
+
+func AlwaysTrue(t *testing.T) Condition {
+	return FuncCondition(t, func(communityId string, roomId string, senderUserId string) bool {
+		return true
+	})
+}
+
+func TestAlwaysTrue(t *testing.T) {
+	c := AlwaysTrue(t)
+	assert.True(t, c.Matches(context.Background(), "whatever", "whatever", "whatever"))
+}
+
+func AlwaysFalse(t *testing.T) Condition {
+	return FuncCondition(t, func(communityId string, roomId string, senderUserId string) bool {
+		return false
+	})
+}
+
+func TestAlwaysFalse(t *testing.T) {
+	c := AlwaysFalse(t)
+	assert.False(t, c.Matches(context.Background(), "whatever", "whatever", "whatever"))
+}
+
+type TestCondition struct {
+	t  *testing.T
+	fn TestConditionMatchesFn
+}
+
+func FuncCondition(t *testing.T, fn TestConditionMatchesFn) *TestCondition {
+	return &TestCondition{
+		t:  t,
+		fn: fn,
+	}
+}
+
+func (c *TestCondition) Matches(ctx context.Context, communityId string, roomId string, senderUserId string) bool {
+	assert.NotNil(c.t, ctx, "context is required")
+	return c.fn(communityId, roomId, senderUserId)
+}
+
+func TestFuncCondition(t *testing.T) {
+	c := FuncCondition(t, func(communityId string, roomId string, senderUserId string) bool {
+		return communityId == "return true"
+	})
+	assert.True(t, c.Matches(context.Background(), "return true", "whatever", "whatever"))
+	assert.False(t, c.Matches(context.Background(), "whatever", "whatever", "whatever"))
+}

--- a/filter/filter_ai_executor.go
+++ b/filter/filter_ai_executor.go
@@ -2,9 +2,9 @@ package filter
 
 import (
 	"context"
-	"slices"
 
 	"github.com/matrix-org/policyserv/ai"
+	"github.com/matrix-org/policyserv/filter/condition"
 	"github.com/matrix-org/policyserv/harms"
 )
 
@@ -13,17 +13,16 @@ type InstancedAIExecutorFilter[ConfigT any] struct {
 	set        *Set
 	config     ConfigT
 	aiProvider ai.Provider[ConfigT]
-	inRoomIds  []string
 }
 
-func NewInstancedAIExecutorFilter[ConfigT any](name string, set *Set, config ConfigT, aiProvider ai.Provider[ConfigT], inRoomIds []string) *InstancedAIExecutorFilter[ConfigT] {
-	return &InstancedAIExecutorFilter[ConfigT]{
+func NewInstancedAIExecutorFilter[ConfigT any](name string, set *Set, config ConfigT, aiProvider ai.Provider[ConfigT], inRoomIds []string) InstancedEventFilter {
+	instanced := &InstancedAIExecutorFilter[ConfigT]{
 		name:       name,
 		set:        set,
 		config:     config,
 		aiProvider: aiProvider,
-		inRoomIds:  inRoomIds,
 	}
+	return NewConditionalFilter(set, instanced, condition.AnyIn(condition.RoomId, inRoomIds))
 }
 
 func (f *InstancedAIExecutorFilter[ConfigT]) Name() string {
@@ -31,9 +30,6 @@ func (f *InstancedAIExecutorFilter[ConfigT]) Name() string {
 }
 
 func (f *InstancedAIExecutorFilter[ConfigT]) CheckEvent(ctx context.Context, input *EventInput) (*harms.ContentInfo, error) {
-	if !slices.Contains(f.inRoomIds, input.Event.RoomID().String()) {
-		return harms.NeutralContent(), nil // this filter isn't allowed to execute in here
-	}
 	return f.aiProvider.CheckEvent(ctx, f.config, &ai.Input{
 		Event:  input.Event,
 		Medias: input.Medias,

--- a/filter/filter_conditional.go
+++ b/filter/filter_conditional.go
@@ -1,0 +1,74 @@
+package filter
+
+import (
+	"context"
+	"log"
+
+	"github.com/matrix-org/policyserv/filter/condition"
+	"github.com/matrix-org/policyserv/harms"
+)
+
+// ConditionalFilter - An instanced filter which only runs the downstream filter when the condition is met. Note
+// that this implements all types of Instanced filters despite the downstream filter potentially not being so broad.
+// This is done for ease of type definitions - a neutral content info will be returned if the filter is asked to
+// check a content type that the downstream filter doesn't support.
+//
+// NOTE: Text filters don't have enough information to actually run the conditions, so InstancedTextFilter will always
+// be run despite conditions. If a downstream filter is also an InstancedEventFilter, CheckEvent will be conditionally
+// run.
+type ConditionalFilter struct {
+	set        *Set
+	condition  condition.Condition
+	downstream Instanced
+}
+
+func NewConditionalFilter(set *Set, downstream Instanced, condition condition.Condition) *ConditionalFilter {
+	// Check early if the downstream is capable of being used with the ConditionalFilter.
+	// Dev note: Update this check as ConditionalFilter gains more content types.
+	_, isEventFilter := downstream.(InstancedEventFilter)
+	_, isTextFilter := downstream.(InstancedTextFilter)
+	if !isEventFilter && !isTextFilter {
+		panic("developer error: expected downstream filter to be at least an event or text filter, got neither")
+	}
+
+	return &ConditionalFilter{
+		set:        set,
+		condition:  condition,
+		downstream: downstream,
+	}
+}
+
+// Name - Implements Instanced.
+func (c *ConditionalFilter) Name() string {
+	// Copy the name verbatim. We don't indicate that the filter is conditional in the name because that fact isn't
+	// important for metrics or log line prefixes. We log elsewhere which conditions are being run.
+	return c.downstream.Name()
+}
+
+// CheckEvent - Implements InstancedEventFilter.
+func (c *ConditionalFilter) CheckEvent(ctx context.Context, input *EventInput) (*harms.ContentInfo, error) {
+	eventFilter, ok := c.downstream.(InstancedEventFilter)
+	if !ok {
+		// Per docs on ConditionalFilter, return neutral when unsupported content type
+		return harms.NeutralContent(), nil
+	}
+
+	if !c.condition.Matches(ctx, c.set.communityId, input.Event.RoomID().String(), string(input.Event.SenderID())) {
+		log.Printf("[%s | %s] Condition did not match - returning neutral content to skip", input.Event.EventID(), input.Event.RoomID().String())
+		return harms.NeutralContent(), nil
+	}
+
+	log.Printf("[%s | %s] Condition matched - calling downstream filter", input.Event.EventID(), input.Event.RoomID().String())
+	return eventFilter.CheckEvent(ctx, input)
+}
+
+// CheckText - Implements InstancedTextFilter.
+func (c *ConditionalFilter) CheckText(ctx context.Context, input string) (*harms.ContentInfo, error) {
+	textFilter, ok := c.downstream.(InstancedTextFilter)
+	if !ok {
+		// Per docs on ConditionalFilter, return neutral when unsupported content type
+		return harms.NeutralContent(), nil
+	}
+	// We don't have enough information to pass to the condition's Matches function, so run the filter unconditionally.
+	return textFilter.CheckText(ctx, input)
+}

--- a/filter/filter_conditional_test.go
+++ b/filter/filter_conditional_test.go
@@ -1,0 +1,72 @@
+package filter
+
+import (
+	"context"
+	"testing"
+
+	"github.com/matrix-org/policyserv/filter/condition"
+	"github.com/matrix-org/policyserv/harms"
+	"github.com/matrix-org/policyserv/test"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestConditionalFilter(t *testing.T) {
+	// Note: other tests ensure that the filter is properly created from the EnabledNames slice. This test
+	// ensures that the condition is actually respected.
+
+	event1 := test.MustMakePDU(&test.BaseClientEvent{
+		EventId: "$event1",
+		RoomId:  "!foo:example.org",
+		Type:    "m.room.message",
+		Content: map[string]any{
+			"body": "doesn't matter",
+		},
+	})
+	event2 := test.MustMakePDU(&test.BaseClientEvent{
+		EventId: "$event2",
+		RoomId:  "!wrong_room:example.org",
+		Type:    "m.room.message",
+		Content: map[string]any{
+			"body": "doesn't matter",
+		},
+	})
+	set := &Set{
+		// We don't use much of the Set in this case, so we can populate the minimum we need
+		// rather than create it properly.
+
+		communityId: "example",
+	}
+	instanced := &FixedInstancedFilter{
+		T:   t,
+		Set: set,
+		Expect: &EventInput{
+			Event:  event1,
+			Medias: nil,
+		},
+		ExpectText: "testing123",
+		ReturnInfo: harms.ProhibitedContent(harms.SpamFlooding), // so we can verify the filter was called
+		ReturnErr:  nil,
+	}
+	cond := condition.RoomId("!foo:example.org")
+
+	f := NewConditionalFilter(set, instanced, cond)
+	assert.NotNil(t, f)
+
+	// First event should go through to filter
+	info, err := f.CheckEvent(context.Background(), &EventInput{
+		Event:        event1,
+		Medias:       nil,
+		auditContext: &auditContext{}, // not used, but needs to be populated to appease FixedFilter
+	})
+	assert.NoError(t, err)
+	test.AssertEqualContentInfo(t, harms.ProhibitedContent(harms.SpamFlooding), info)
+
+	// Second event should not (wrong room ID)
+	info, err = f.CheckEvent(context.Background(), &EventInput{
+		Event:        event2,
+		Medias:       nil,
+		auditContext: &auditContext{}, // not used, but needs to be populated to appease FixedFilter
+	})
+	assert.NoError(t, err)
+	test.AssertEqualContentInfo(t, harms.NeutralContent(), info)
+}

--- a/filter/filter_openai_omni_test.go
+++ b/filter/filter_openai_omni_test.go
@@ -1,6 +1,7 @@
 package filter
 
 import (
+	"context"
 	"testing"
 
 	"github.com/matrix-org/policyserv/ai"
@@ -45,7 +46,10 @@ func TestOpenAIOmniFilter(t *testing.T) {
 
 	// Pull the filter out of the set to inspect its type & config.
 	// If this for some reason isn't "ok", then the filter created the very wrong thing.
-	instanced, ok := set.groups[0].filters[0].(*InstancedAIExecutorFilter[*ai.OpenAIOmniModerationConfig])
+	conditional, ok := set.groups[0].filters[0].(*ConditionalFilter)
+	assert.True(t, ok)
+	assert.NotNil(t, conditional)
+	instanced, ok := conditional.downstream.(*InstancedAIExecutorFilter[*ai.OpenAIOmniModerationConfig])
 	assert.True(t, ok)
 	assert.NotNil(t, instanced)
 
@@ -55,7 +59,10 @@ func TestOpenAIOmniFilter(t *testing.T) {
 	assert.Equal(t, &ai.OpenAIOmniModerationConfig{
 		FailSecure: true, // should have been set by pulling in the community config above
 	}, instanced.config)
-	assert.Equal(t, []string{"!allowed:example.org"}, instanced.inRoomIds) // should have been pulled from instance config
+
+	// Verify the conditional filter got set up correctly, and is using the instance config
+	assert.True(t, conditional.condition.Matches(context.Background(), "whatever", "!allowed:example.org", "whatever"))
+	assert.False(t, conditional.condition.Matches(context.Background(), "whatever", "!wrong:example.org", "whatever"))
 
 	// Verify that the provider is correct. Note that the provider verifies it got a non-empty API key, so this also
 	// tests that we got *something* resembling an API key as far as the provider. We can't really test that the exact


### PR DESCRIPTION
This is over-engineered for the limited use case at the moment, but in future we'd use this to do more elaborate things like only turn on filters in specific rooms/communities, or only run a filter during a certain time of day.

In future we would also probably not leave it to the filter constructors to use conditions themselves, but rather have a layer which does it for any filter.

This is a step towards https://github.com/matrix-org/policyserv/issues/8 being somewhat possible. Short-ish term we're looking to develop a TimeOfDay condition so we can run certain AI models at specific times. Longer term we could add a condition which relies on filters itself. For example, "if density is high, rely on the URL detection filter's result".

### Pull Request Checklist

<!-- Please read https://github.com/matrix-org/policyserv/CONTRIBUTING.md before submitting your pull request -->

* [x] Pull request is based on the `main` branch.
* [x] Pull request title describes the changes in a way a user would understand. For example, "Fix keywords filter not applying" instead of "Read keywords slice in a loop".
* [x] Code style matches surrounding code.
* [x] Tests are added for new code (and existing code) if possible.
  * If not possible, please explain why in your PR description. 
* [x] The CI checks pass.
